### PR TITLE
Fixed PR-AWS-TRF-SG-008: AWS Security Groups allow internet traffic to SSH port (22)

### DIFF
--- a/aws/sg/extrasg.tf
+++ b/aws/sg/extrasg.tf
@@ -107,17 +107,6 @@ resource "aws_security_group" "default" {
 
   # SSH access from anywhere
 
-  ingress {
-
-    from_port = 22
-
-    to_port = 22
-
-    protocol = "tcp"
-
-    cidr_blocks = ["0.0.0.0/0"]
-
-  }
 
 
 


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-SG-008 

 **Violation Description:** 

 This policy identifies AWS Security Groups which do allow inbound traffic on SSH port (22) from public internet. Doing so, may allow a bad actor to brute force their way into the system and potentially get access to the entire network. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented at this URL: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html