### PR TITLE
Fixed PR-AWS-TRF-NACL-005: AWS Network ACLs with Outbound rule to allow All ICMP IPv6

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -254,7 +254,7 @@ resource "aws_network_acl_rule" "ingress1" {
 }
 
 resource "aws_network_acl_rule" "ingress2" {
-  network_acl_id = ""
+  network_acl_id  = ""
   rule_number     = 200
   egress          = false
   protocol        = -1
@@ -276,11 +276,11 @@ resource "aws_network_acl_rule" "egress1" {
 }
 
 resource "aws_network_acl_rule" "egress2" {
-  network_acl_id = ""
+  network_acl_id  = ""
   rule_number     = 200
   egress          = true
   protocol        = -1
-  rule_action     = "allow"
+  rule_action     = "deny"
   ipv6_cidr_block = "::/0"
   from_port       = 22
   to_port         = 22
@@ -573,10 +573,10 @@ resource "aws_route53_record" "www" {
 }
 
 resource "aws_sagemaker_notebook_instance" "ni" {
-  name          = "my-notebook-instance"
-  role_arn      = aws_iam_role.role.arn
-  instance_type = "ml.t2.medium"
-  root_access   = "Enabled"
+  name                   = "my-notebook-instance"
+  role_arn               = aws_iam_role.role.arn
+  instance_type          = "ml.t2.medium"
+  root_access            = "Enabled"
   direct_internet_access = "Enabled"
 
   subnet_id = []


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-NACL-005 

 **Violation Description:** 

 This policy identifies ACLs which allows traffic on all protocol. A network access control list (ACL) is an optional layer of security for your VPC that acts as a firewall for controlling traffic in and out of one or more subnets. By default, ACL allows all inbound and outbound IPv4 traffic and, if applicable, IPv6 traffic. Outbound rules that allow unrestricted traffic to the internet can be a security risk. As a best practice, it is recommended to configure ACL to restrict traffic on authorized protocols. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented at this URL: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html