### PR TITLE
PR-AZR-0104-TRF: Ensure that admin user is disabled for Container Registry

### DIFF
--- a/azure/containerregistry/terraform.tfvars
+++ b/azure/containerregistry/terraform.tfvars
@@ -1,16 +1,16 @@
-location                     = "eastus2"
-resource_group               = "prancer-test-rg"
+location       = "eastus2"
+resource_group = "prancer-test-rg"
 
 acr_name                     = "pranceracr"
 acr_sku                      = "Classic"
-acr_admin_enabled            = true
+acr_admin_enabled            = false
 acr_georeplication_locations = null
 
-acr_webhook_name             = "pranceracrhook"
-acr_webhook_service_uri      = "http://mywebhookreceiver.example/mytag"
-acr_webhook_status           = "enabled"
-acr_webhook_scope            = "mytag:*"
-acr_webhook_actions          = ["push"]
-acr_webhook_custom_headers   = { "Content-Type" = "application/json" }
+acr_webhook_name           = "pranceracrhook"
+acr_webhook_service_uri    = "http://mywebhookreceiver.example/mytag"
+acr_webhook_status         = "enabled"
+acr_webhook_scope          = "mytag:*"
+acr_webhook_actions        = ["push"]
+acr_webhook_custom_headers = { "Content-Type" = "application/json" }
 
-tags                         = {}
+tags = {}


### PR DESCRIPTION
**Violation Id:** PR-AZR-0104-TRF 

 **Violation Description:** 

 The value that indicates whether the admin user is enabled. Each container registry includes an admin user account, which is disabled by default. You can enable the admin user and manage its credentials in the Azure portal, or by using the Azure CLI or other Azure tools. All users authenticating with the admin account appear as a single user with push and pull access to the registry. Changing or disabling this account disables registry access for all users who use its credentials. 

 **How to Fix:** 

 In 'azurerm_container_registry' resource, set 'admin_enabled = false' or remove 'admin_enabled' property to fix the issue. Visit https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry#admin_enabled for details.