### PR TITLE
PR-AZR-0123-TRF: Ensure that Storage Account should not allow public access to all blobs or containers

### DIFF
--- a/azure/storageaccounts/terraform.tfvars
+++ b/azure/storageaccounts/terraform.tfvars
@@ -1,22 +1,22 @@
-resource_group_name       = "prancer-test-rg"
-location                  = "eastus2"
+resource_group_name = "prancer-test-rg"
+location            = "eastus2"
 
-storage_count             = 1
-storage_name              = "prancerstorageaccount007"
-accountTier               = "Standard"
-replicationType           = "LRS"
-enableSecureTransfer      = false
-allow_blob_public_access  = true
+storage_count            = 1
+storage_name             = "prancerstorageaccount007"
+accountTier              = "Standard"
+replicationType          = "LRS"
+enableSecureTransfer     = false
+allow_blob_public_access = false
 
-default_action             = "Allow"
-ip_rules                   = ["1.1.1.1"]
-bypass                     = ["Metrics"]
+default_action = "Allow"
+ip_rules       = ["1.1.1.1"]
+bypass         = ["Metrics"]
 
 storage_container_name        = "prancer-storage-container"
 storage_container_access_type = "private"
 
-storage_blob_name         = "prancer-storage-blob"
-storage_blob_type         = "Block"
-storage_blob_size         = "5120"
+storage_blob_name = "prancer-storage-blob"
+storage_blob_type = "Block"
+storage_blob_size = "5120"
 
 tags = {}


### PR DESCRIPTION
**Violation Id:** PR-AZR-0123-TRF 

 **Violation Description:** 

 This policy will identify which Storage Account has public access not disabled for all blobs or containers and alert 

 **How to Fix:** 

 In 'azurerm_storage_account' resource, set 'allow_blob_public_access = false' to fix the issue. Visit https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account#allow_blob_public_access for details.