### PR TITLE
Fixed PR-AWS-CFR-MQ-002: Ensure Amazon MQ Broker logging is enabled

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -254,7 +254,7 @@ resource "aws_network_acl_rule" "ingress1" {
 }
 
 resource "aws_network_acl_rule" "ingress2" {
-  network_acl_id = ""
+  network_acl_id  = ""
   rule_number     = 200
   egress          = false
   protocol        = -1
@@ -276,7 +276,7 @@ resource "aws_network_acl_rule" "egress1" {
 }
 
 resource "aws_network_acl_rule" "egress2" {
-  network_acl_id = ""
+  network_acl_id  = ""
   rule_number     = 200
   egress          = true
   protocol        = -1
@@ -467,6 +467,9 @@ resource "aws_mq_broker" "example" {
     username = "ExampleUser"
     password = "MindTheGap"
   }
+  logs {
+    general = "true"
+  }
 }
 
 resource "aws_api_gateway_authorizer" "demo" {
@@ -573,10 +576,10 @@ resource "aws_route53_record" "www" {
 }
 
 resource "aws_sagemaker_notebook_instance" "ni" {
-  name          = "my-notebook-instance"
-  role_arn      = aws_iam_role.role.arn
-  instance_type = "ml.t2.medium"
-  root_access   = "Enabled"
+  name                   = "my-notebook-instance"
+  role_arn               = aws_iam_role.role.arn
+  instance_type          = "ml.t2.medium"
+  root_access            = "Enabled"
   direct_internet_access = "Enabled"
 
   subnet_id = []


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-MQ-002 

 **Violation Description:** 

 Amazon MQ is integrated with CloudTrail and provides a record of the Amazon MQ calls made by a user, role, or AWS service. It supports logging both the request parameters and the responses for APIs as events in CloudTrail 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented at this URL: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/mq_broker