### PR TITLE
Fixed PR-AWS-TRF-AG-003: AWS API gateway request authorization is not set

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -254,7 +254,7 @@ resource "aws_network_acl_rule" "ingress1" {
 }
 
 resource "aws_network_acl_rule" "ingress2" {
-  network_acl_id = ""
+  network_acl_id  = ""
   rule_number     = 200
   egress          = false
   protocol        = -1
@@ -276,7 +276,7 @@ resource "aws_network_acl_rule" "egress1" {
 }
 
 resource "aws_network_acl_rule" "egress2" {
-  network_acl_id = ""
+  network_acl_id  = ""
   rule_number     = 200
   egress          = true
   protocol        = -1
@@ -474,6 +474,7 @@ resource "aws_api_gateway_authorizer" "demo" {
   rest_api_id            = aws_api_gateway_rest_api.demo.id
   authorizer_uri         = aws_lambda_function.authorizer.invoke_arn
   authorizer_credentials = aws_iam_role.invocation_role.arn
+  type                   = "REQUEST"
 }
 
 resource "aws_api_gateway_rest_api" "demo" {
@@ -573,10 +574,10 @@ resource "aws_route53_record" "www" {
 }
 
 resource "aws_sagemaker_notebook_instance" "ni" {
-  name          = "my-notebook-instance"
-  role_arn      = aws_iam_role.role.arn
-  instance_type = "ml.t2.medium"
-  root_access   = "Enabled"
+  name                   = "my-notebook-instance"
+  role_arn               = aws_iam_role.role.arn
+  instance_type          = "ml.t2.medium"
+  root_access            = "Enabled"
   direct_internet_access = "Enabled"
 
   subnet_id = []
@@ -594,7 +595,7 @@ resource "aws_dax_cluster" "bar" {
   replication_factor = 1
 
   server_side_encryption {
-    enabled          = false
+    enabled = false
   }
 }
 


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-AG-003 

 **Violation Description:** 

 This policy identifies AWS API Gateways of protocol type REST for which the request authorisation is not set. The method request for API gateways takes the client input that is passed to the back end through the integration request. It is recommended to add authorization type to each of the method to add a layer of protection. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented at this URL: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_authorizer