### PR TITLE
Fixed PR-AZR-TRF-AGW-001: Azure Application Gateway should use TLSv1.2 as minimum version or higher

### DIFF
--- a/azure/applicationgateways/terraform.tfvars
+++ b/azure/applicationgateways/terraform.tfvars
@@ -1,19 +1,19 @@
-location              = "eastus2"
-vnet_name             = "prancer-vnet"
-resource_group        = "prancer-test-rg"
-address_space         = "10.254.0.0/16"
-dns_server            = "10.254.0.1"
+location       = "eastus2"
+vnet_name      = "prancer-vnet"
+resource_group = "prancer-test-rg"
+address_space  = "10.254.0.0/16"
+dns_server     = "10.254.0.1"
 
-subnet_name_fe        = "prancer-frontend"
-address_prefixes_fe   = ["10.254.0.0/24"]
+subnet_name_fe      = "prancer-frontend"
+address_prefixes_fe = ["10.254.0.0/24"]
 
-subnet_name_be        = "prancer-backend"
-address_prefixes_be   = ["10.254.2.0/24"]
+subnet_name_be      = "prancer-backend"
+address_prefixes_be = ["10.254.2.0/24"]
 
-pip_name              = "prancer-pip"
-pip_type              = "Dynamic"
-pip_sku               = "Basic"
-ip_version            = "IPv4"
+pip_name   = "prancer-pip"
+pip_type   = "Dynamic"
+pip_sku    = "Basic"
+ip_version = "IPv4"
 
 app_gw_name            = "prancer-app-gw"
 app_gw_sku             = "WAF_Medium"
@@ -28,13 +28,13 @@ app_gw_be_http_proto   = "Http"
 app_gw_be_http_timeout = "60"
 app_gw_listener_proto  = "Http"
 app_gw_req_route_type  = "Basic"
-min_protocol_version   = "TLSv1_0"
+min_protocol_version   = "tlsv1_3"
 waf_enabled            = false
 waf_firewall_mode      = "Detection"
 waf_rule_set_type      = "OWASP"
 waf_rule_set_version   = "2.2.9"
 
-tags                   = {
+tags = {
   environment = "Production"
   project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-AGW-001 

 **Violation Description:** 

 The Application Gateway supports end-to-end SSL encryption using multiple TLS versions and by default, it supports TLS version 1.0 as the minimum version.<br><br>This policy identifies the Application Gateway instances that are configured to use TLS versions 1.1 or lower as the minimum protocol version. As a best practice set the MinProtocolVersion to TLSv1.2 (if you use custom SSL policy) or use the predefined AppGwSslPolicy20170401S policy. 

 **How to Fix:** 

 In 'azurerm_application_gateway' resource, set min_protocol_version = 'TLSv1_2' under 'ssl_policy' block to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_gateway#min_protocol_version' target='_blank'>here</a> for details.