### PR TITLE
Fixed PR-AZR-TRF-AGW-002: Azure Application Gateway should have Web application firewall (WAF) enabled

### DIFF
--- a/azure/modules/applicationGateway/main.tf
+++ b/azure/modules/applicationGateway/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_application_gateway" "appgw" {
   }
 
   frontend_ip_configuration {
-    name                 = "${var.app_gw_name}-fe-ip"
+    name = "${var.app_gw_name}-fe-ip"
   }
 
   backend_address_pool {
@@ -53,6 +53,7 @@ resource "azurerm_application_gateway" "appgw" {
 
   ssl_policy {
     min_protocol_version = var.min_protocol_version
+    enabled              = true
   }
 
   waf_configuration {


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-AGW-002 

 **Violation Description:** 

 This policy identifies Azure Application Gateways that do not have Web application firewall (WAF) enabled. As a best practice, enable WAF to manage and protect your web applications behind the Application Gateway from common exploits and vulnerabilities. 

 **How to Fix:** 

 In 'azurerm_application_gateway' resource, set enabled = true under 'waf_configuration' block to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_gateway#waf_configuration' target='_blank'>here</a> for details.