### PR TITLE
Fixed PR-AZR-TRF-DBK-001: Azure Databricks shoud not use public IP address

### DIFF
--- a/azure/databricks/terraform.tfvars
+++ b/azure/databricks/terraform.tfvars
@@ -1,6 +1,6 @@
-location                        = "eastus2"
-rg_name                         = "prancer-test-rg"
-name                            = "prancer-adb-workspace"
-no_public_ip                    = false
-virtual_network_id              = null
-tags                            = {}
+location           = "eastus2"
+rg_name            = "prancer-test-rg"
+name               = "prancer-adb-workspace"
+no_public_ip       = true
+virtual_network_id = null
+tags               = {}


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-DBK-001 

 **Violation Description:** 

 Azure Databricks is a data analytics platform optimized for the Microsoft Azure cloud services platform. This policy will identify Databricks which does not have public ip disabled and warn. 

 **How to Fix:** 

 In 'azurerm_databricks_workspace' resource, set true as the value of 'no_public_ip' under 'custom_parameters' block to fix the issue. If 'custom_parameters' block does not exist please add one. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/databricks_workspace' target='_blank'>here</a> for details.