### PR TITLE
Fixed PR-AZR-TRF-SQL-053: Azure SQL Server audit log retention should be greater then 90 days

### DIFF
--- a/azure/modules/sqlServer/main.tf
+++ b/azure/modules/sqlServer/main.tf
@@ -1,11 +1,14 @@
 resource "azurerm_sql_server" "sqlserver" {
-  name                         = var.server_name
-  resource_group_name          = var.server_rg
-  location                     = var.location
+  name                = var.server_name
+  resource_group_name = var.server_rg
+  location            = var.location
 
   version                      = var.server_version
   administrator_login          = var.admin_user
   administrator_login_password = var.admin_password
 
-  tags                         = var.tags
+  tags = var.tags
+  extended_auditing_policy {
+    retention_in_days = 91
+  }
 }


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-SQL-053 

 **Violation Description:** 

 Audit Logs can help you find suspicious events, unusual activity, and trends. Auditing the SQL server, at the server-level, allows you to track all existing and newly created databases on the instance.<br><br>This policy identifies SQL servers which do not retain audit logs for more than 90 days. As a best practice, configure the audit logs retention time period to be greater than 90 days. 

 **How to Fix:** 

 In 'azurerm_sql_server' resource, set the 'retention_in_days = 91' under 'extended_auditing_policy' block to fix the issue. please visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/sql_server#retention_in_days' target='_blank'>here</a> for details.