### PR TITLE
Fixed PR-AZR-TRF-KV-003: Key vault should have purge protection enabled

### DIFF
--- a/azure/modules/keyVault/main.tf
+++ b/azure/modules/keyVault/main.tf
@@ -5,9 +5,9 @@ resource "azurerm_key_vault" "keyvault" {
   location            = var.location
   resource_group_name = var.resourceGroup
 
-  sku_name            = var.skuname
+  sku_name = var.skuname
 
-  tenant_id           = data.azurerm_client_config.current.tenant_id
+  tenant_id = data.azurerm_client_config.current.tenant_id
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
@@ -22,5 +22,6 @@ resource "azurerm_key_vault" "keyvault" {
   enabled_for_deployment          = var.enabled_for_deployment
   enabled_for_template_deployment = var.enabled_for_template_deployment
 
-  tags = var.tags
+  tags                     = var.tags
+  purge_protection_enabled = true
 }


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-KV-003 

 **Violation Description:** 

 The key vault contains object keys, secrets and certificates. Accidental unavailability of a key vault can cause immediate data loss or loss of security functions (authentication, validation, verification, non-repudiation 

 **How to Fix:** 

 In 'azurerm_key_vault' resource, set 'purge_protection_enabled = true' to fix the issue. Please visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault#purge_protection_enabled' target='_blank'>here</a> for details.