### PR TITLE
Fixed PR-AZR-TRF-SQL-016: Ensure MySQL Database Server accepts only SSL connections

### DIFF
--- a/azure/modules/mysqlServer/main.tf
+++ b/azure/modules/mysqlServer/main.tf
@@ -1,17 +1,17 @@
 resource "azurerm_mysql_server" "mysqlserver" {
-  name                          = var.server_name
-  resource_group_name           = var.server_rg
-  location                      = var.location
+  name                = var.server_name
+  resource_group_name = var.server_rg
+  location            = var.location
 
-  administrator_login           = var.admin_user
-  administrator_login_password  = var.admin_password
+  administrator_login          = var.admin_user
+  administrator_login_password = var.admin_password
 
   sku_name   = "GP_Gen5_8"
   storage_mb = 5120
   version    = var.server_version
 
   public_network_access_enabled = var.public_network_access_enabled
-  ssl_enforcement_enabled       = false
+  ssl_enforcement_enabled       = true
 
-  tags                         = var.tags
+  tags = var.tags
 }


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-SQL-016 

 **Violation Description:** 

 This policy will identify MySQL Database Server which are not enforcing all the incoming connection over SSL and alert if found. 

 **How to Fix:** 

 In 'azurerm_mysql_server' resource, set 'ssl_enforcement_enabled = true' to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mysql_server#ssl_enforcement_enabled' target='_blank'>here</a> for details.