### PR TITLE
Fixed PR-AZR-TRF-ASC-001: Azure Security Center should have pricing tier configured to 'standard'

### DIFF
--- a/azure/securitycenterpricing/terraform.tfvars
+++ b/azure/securitycenterpricing/terraform.tfvars
@@ -1,1 +1,1 @@
-subscription_pricing_tier = "Free"
+subscription_pricing_tier = "Standard"


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-ASC-001 

 **Violation Description:** 

 Selecting the standard pricing tier will enable threat detection for networks and virtual systems by providing threat intelligence, anomaly detection, and behavior analytics in Azure Security Center. 

 **How to Fix:** 

 In 'azurerm_security_center_subscription_pricing' resource, set tier = 'standard' to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/security_center_subscription_pricing#tier' target='_blank'>here</a> for details.