### PR TITLE
Fixed PR-AZR-TRF-ACR-001: Azure ACR should have HTTPS protocol enabled for webhook

### DIFF
--- a/azure/containerregistry/terraform.tfvars
+++ b/azure/containerregistry/terraform.tfvars
@@ -1,16 +1,16 @@
-location                     = "eastus2"
-resource_group               = "prancer-test-rg"
+location       = "eastus2"
+resource_group = "prancer-test-rg"
 
 acr_name                     = "pranceracr"
 acr_sku                      = "Classic"
 acr_admin_enabled            = true
 acr_georeplication_locations = null
 
-acr_webhook_name             = "pranceracrhook"
-acr_webhook_service_uri      = "http://mywebhookreceiver.example/mytag"
-acr_webhook_status           = "enabled"
-acr_webhook_scope            = "mytag:*"
-acr_webhook_actions          = ["push"]
-acr_webhook_custom_headers   = { "Content-Type" = "application/json" }
+acr_webhook_name           = "pranceracrhook"
+acr_webhook_service_uri    = "https://mywebhookreceiver.example/mytag"
+acr_webhook_status         = "enabled"
+acr_webhook_scope          = "mytag:*"
+acr_webhook_actions        = ["push"]
+acr_webhook_custom_headers = { "Content-Type" = "application/json" }
 
-tags                         = {}
+tags = {}


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-ACR-001 

 **Violation Description:** 

 Ensure you send container registry webhooks only to a HTTPS endpoint. This policy checks your container registry webhooks and alerts if it finds a URI with HTTP. 

 **How to Fix:** 

 In 'azurerm_container_registry_webhook' resource, set secure http (https) based wekhook url at 'service_uri' property to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry_webhook#service_uri' target='_blank'>here</a> for details.