### PR TITLE
Fixed PR-AZR-TRF-ASC-003: Security Center shoud send security alerts notifications to the security contact

### DIFF
--- a/azure/securitycentercontact/terraform.tfvars
+++ b/azure/securitycentercontact/terraform.tfvars
@@ -1,4 +1,4 @@
 sec_center_email              = "none"
 sec_center_phone              = ""
-sec_center_alert_notification = false
+sec_center_alert_notification = true
 sec_center_alerts_to_admin    = false


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-ASC-003 

 **Violation Description:** 

 This policy will identify security centers which dont have configuration enabled to send security alerts notifications to the security contact and alert if missing. 

 **How to Fix:** 

 In 'azurerm_security_center_contact' resource, set 'alert_notifications = true' to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/security_center_contact#alert_notifications' target='_blank'>here</a> for details.