### PR TITLE
Fixed PR-AZR-TRF-ASC-005: Security Center shoud send security alerts notifications to subscription admins

### DIFF
--- a/azure/securitycentercontact/terraform.tfvars
+++ b/azure/securitycentercontact/terraform.tfvars
@@ -1,4 +1,4 @@
 sec_center_email              = "none"
 sec_center_phone              = ""
 sec_center_alert_notification = false
-sec_center_alerts_to_admin    = false
+sec_center_alerts_to_admin    = true


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-ASC-005 

 **Violation Description:** 

 This policy will identify security centers which dont have configuration enabled to send security alerts notifications to subscription admins and alert if missing. 

 **How to Fix:** 

 In 'azurerm_security_center_contact' resource, set 'alerts_to_admins = true' to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/security_center_contact#alerts_to_admins' target='_blank'>here</a> for details.