### PR TITLE
Fixed PR-AZR-TRF-STR-003: Storage Accounts https based secure transfer should be enabled

### DIFF
--- a/azure/diagnosticsettings/terraform.tfvars
+++ b/azure/diagnosticsettings/terraform.tfvars
@@ -1,14 +1,14 @@
-location                    = "eastus2"
-resource_group              = "prancer-test-rg"
+location       = "eastus2"
+resource_group = "prancer-test-rg"
 
-storage_count               = 1
-storage_name                = "prancerstorageaccount007"
-accountTier                 = "Standard"
-replicationType             = "LRS"
-enableSecureTransfer        = false
+storage_count        = 1
+storage_name         = "prancerstorageaccount007"
+accountTier          = "Standard"
+replicationType      = "LRS"
+enableSecureTransfer = true
 
-kv_name                     = "prancer-key-vault"
-kv_sku                      = "standard"
+kv_name = "prancer-key-vault"
+kv_sku  = "standard"
 
 ds_name                     = "prancer-kv-diagnostic"
 ds_log_category             = "AuditEvent"
@@ -20,4 +20,4 @@ ds_metric_enabled           = true
 ds_metric_retention_enabled = true
 ds_metric_retention_days    = 7
 
-tags                        = {}
+tags = {}


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-STR-003 

 **Violation Description:** 

 The secure transfer option enhances the security of your storage account by only allowing requests to the storage account by a secure connection. For example, when calling REST APIs to access your storage accounts, you must connect using HTTPs. Any requests using HTTP will be rejected when 'secure transfer required' is enabled. When you are using the Azure files service, connection without encryption will fail, including scenarios using SMB 2.1, SMB 3.0 without encryption, and some flavors of the Linux SMB client. Because Azure storage doesn't support HTTPs for custom domain names, this option is not applied when using a custom domain name. 

 **How to Fix:** 

 In 'azurerm_storage_account' resource, set 'enable_https_traffic_only = true' or remove property 'enable_https_traffic_only' to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account#enable_https_traffic_only' target='_blank'>here</a> for details.