### PR TITLE
Fixed PR-AWS-TRF-AG-002: AWS API gateway request parameter is not validated

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -291,7 +291,7 @@ resource "aws_api_gateway_request_validator" "example" {
   name                        = "example"
   rest_api_id                 = aws_api_gateway_rest_api.example.id
   validate_request_body       = true
-  validate_request_parameters = false
+  validate_request_parameters = true
 }
 
 


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-AG-002 

 **Violation Description:** 

 This policy identifies the AWS API gateways for with the request parameters are not validated. It is recommended to validate the request parameters in the URI, query string, and headers of an incoming request to focus on the validation efforts specific to your application.
 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented at this URL: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_request_validator