### PR TITLE
Fixed PR-AWS-TRF-KMS-001: AWS Customer Master Key (CMK) rotation is not enabled

### DIFF
--- a/aws/workspaces/main.tf
+++ b/aws/workspaces/main.tf
@@ -118,5 +118,6 @@ resource "aws_directory_service_directory" "example" {
 }
 
 resource "aws_kms_key" "example" {
-  description = "WorkSpaces example key"
+  description         = "WorkSpaces example key"
+  enable_key_rotation = true
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-KMS-001 

 **Violation Description:** 

 This policy identifies Customer Master Keys (CMKs) that are not enabled with key rotation. AWS KMS (Key Management Service) allows customers to create master keys to encrypt sensitive data in different services. As a security best practice, it is important to rotate the keys periodically so that if the keys are compromised, the data in the underlying service is still secure with the new keys. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented at this URL: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key