### PR TITLE
Fixed PR-AZR-TRF-AKS-009: Kubernetes Dashboard shoud be disabled

### DIFF
--- a/azure/modules/managedClusters/main.tf
+++ b/azure/modules/managedClusters/main.tf
@@ -17,7 +17,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
 
   role_based_access_control {
     azure_active_directory {
-      managed = var.aad_managed
+      managed            = var.aad_managed
       azure_rbac_enabled = var.aad_managed_azure_rbac_enabled
     }
     enabled = var.rbac_enabled
@@ -34,7 +34,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
     }
 
     kube_dashboard {
-      enabled = true
+      enabled = false
     }
   }
 


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-AKS-009 

 **Violation Description:** 

 Disable the Kubernetes dashboard on Azure Kubernetes Service 

 **How to Fix:** 

 In 'azurerm_kubernetes_cluster' resource, set 'kube_dashboard.enabled = true' under 'addon_profile' block to fix the issue. Please visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#kube_dashboard' target='_blank'>here</a> for details.