### PR TITLE
Fixed PR-AZR-TRF-ARC-001: Ensure that the Redis Cache accepts only SSL connections

### DIFF
--- a/azure/rediscache/main.tf
+++ b/azure/rediscache/main.tf
@@ -5,5 +5,5 @@ resource "azurerm_redis_cache" "example" {
   capacity            = 0
   family              = "C"
   sku_name            = "Basic"
-  enable_non_ssl_port = true
+  enable_non_ssl_port = false
 }


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-ARC-001 

 **Violation Description:** 

 It is recommended that Redis Cache should allow only SSL connections. Note: some Redis tools (like redis-cli) do not support SSL. When using such tools plain connection ports should be enabled. 

 **How to Fix:** 

 In 'azurerm_redis_cache' resource, set 'enable_non_ssl_port = false' or remove 'enable_non_ssl_port' property to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_cache#enable_non_ssl_port' target='_blank'>here</a> for details.