### PR TITLE
Fixed PR-AZR-TRF-SQL-028: Ensure Geo-redundant backup is enabled on PostgreSQL database server.

### DIFF
--- a/azure/postgresql_server/terraform.tfvars
+++ b/azure/postgresql_server/terraform.tfvars
@@ -1,15 +1,15 @@
-location                     = "eastus2"
-server_name                  = "prancer-sql-server2"
-server_rg                    = "prancer-test-rg"
-server_version               = "12.0"
-admin_user                   = "prancer_admin"
-admin_password               = "vijcykDaHarj+Oz5"
+location       = "eastus2"
+server_name    = "prancer-sql-server2"
+server_rg      = "prancer-test-rg"
+server_version = "12.0"
+admin_user     = "prancer_admin"
+admin_password = "vijcykDaHarj+Oz5"
 
 auto_grow_enabled            = true
 backup_retention_days        = 7
-geo_redundant_backup_enabled = false
+geo_redundant_backup_enabled = true
 sku_name                     = "GP_Gen5_2"
 ssl_enforcement_enabled      = false
 storage_mb                   = 51200
 
-tags             = {}
+tags = {}


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-SQL-028 

 **Violation Description:** 

 Azure Database for PostgreSQL provides the flexibility to choose between locally redundant or geo-redundant backup storage in the General Purpose and Memory Optimized tiers. When the backups are stored in geo-redundant backup storage, they are not only stored within the region in which your server is hosted, but are also replicated to a paired data center. This provides better protection and ability to restore your server in a different region in the event of a disaster. The Basic tier only offers locally redundant backup storage. 

 **How to Fix:** 

 In 'azurerm_postgresql_server' resource, set 'geo_redundant_backup_enabled = true' to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_server#geo_redundant_backup_enabled' target='_blank'>here</a> for details.