### PR TITLE
Fixed PR-AZR-TRF-SQL-029: Ensure ssl enforcement is enabled on PostgreSQL Database Server.

### DIFF
--- a/azure/postgresql_server/terraform.tfvars
+++ b/azure/postgresql_server/terraform.tfvars
@@ -1,15 +1,15 @@
-location                     = "eastus2"
-server_name                  = "prancer-sql-server2"
-server_rg                    = "prancer-test-rg"
-server_version               = "12.0"
-admin_user                   = "prancer_admin"
-admin_password               = "vijcykDaHarj+Oz5"
+location       = "eastus2"
+server_name    = "prancer-sql-server2"
+server_rg      = "prancer-test-rg"
+server_version = "12.0"
+admin_user     = "prancer_admin"
+admin_password = "vijcykDaHarj+Oz5"
 
 auto_grow_enabled            = true
 backup_retention_days        = 7
 geo_redundant_backup_enabled = false
 sku_name                     = "GP_Gen5_2"
-ssl_enforcement_enabled      = false
+ssl_enforcement_enabled      = true
 storage_mb                   = 51200
 
-tags             = {}
+tags = {}


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-SQL-029 

 **Violation Description:** 

 Enable SSL connection on PostgreSQL Servers. Rationale: SSL connectivity helps to provide a new layer of security, by connecting database server to client applications using Secure Sockets Layer (SSL). Enforcing SSL connections between database server and client applications helps protect against 'man in the middle' attacks by encrypting the data stream between the server and application. 

 **How to Fix:** 

 In 'azurerm_postgresql_server' resource, set 'ssl_enforcement_enabled = true' to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_server#ssl_enforcement_enabled' target='_blank'>here</a> for details.