### PR TITLE
Fixed PR-AZR-TRF-SQL-061: Azure MySQL Server has latest version of tls configured

### DIFF
--- a/azure/modules/mysqlServer/main.tf
+++ b/azure/modules/mysqlServer/main.tf
@@ -1,10 +1,10 @@
 resource "azurerm_mysql_server" "mysqlserver" {
-  name                          = var.server_name
-  resource_group_name           = var.server_rg
-  location                      = var.location
+  name                = var.server_name
+  resource_group_name = var.server_rg
+  location            = var.location
 
-  administrator_login           = var.admin_user
-  administrator_login_password  = var.admin_password
+  administrator_login          = var.admin_user
+  administrator_login_password = var.admin_password
 
   sku_name   = "GP_Gen5_8"
   storage_mb = 5120
@@ -13,5 +13,6 @@ resource "azurerm_mysql_server" "mysqlserver" {
   public_network_access_enabled = var.public_network_access_enabled
   ssl_enforcement_enabled       = false
 
-  tags                         = var.tags
+  tags                             = var.tags
+  ssl_minimal_tls_version_enforced = "TLS1_2"
 }


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-SQL-061 

 **Violation Description:** 

 This policy will identify the Azure MySQL Server which dont have latest version of tls configured and give alert 

 **How to Fix:** 

 In 'azurerm_mysql_server' resource, set ssl_minimal_tls_version_enforced = 'TLS1_2' to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mysql_server#ssl_minimal_tls_version_enforced' target='_blank'>here</a> for details.