### PR TITLE
Fixed PR-AZR-TRF-WEB-008: Azure App Service detaild error message should be enabled

### DIFF
--- a/azure/functionapp/main.tf
+++ b/azure/functionapp/main.tf
@@ -19,9 +19,9 @@ resource "azurerm_app_service" "example" {
 
   site_config {
     dotnet_framework_version = "v4.0"
-    php_version = 7.1
-    python_version = 3.6
-    java_version = "1.7.0_80"
+    php_version              = 7.1
+    python_version           = 3.6
+    java_version             = "1.7.0_80"
     scm_type                 = "LocalGit"
     min_tls_version          = 1.1
     remote_debugging_enabled = true
@@ -55,11 +55,14 @@ resource "azurerm_app_service" "example" {
   }
 
   storage_account {
-    name = ""
-    type = ""
+    name         = ""
+    type         = ""
     account_name = ""
-    share_name = ""
-    access_key = ""
+    share_name   = ""
+    access_key   = ""
+  }
+  logs {
+    detailed_error_messages_enabled = true
   }
 }
 
@@ -85,7 +88,7 @@ resource "azurerm_function_app" "example" {
   storage_account_access_key = azurerm_storage_account.example.primary_access_key
   os_type                    = "linux"
   version                    = "~3"
- auth_settings {
+  auth_settings {
     enabled                       = false
     default_provider              = "AzureActiveDirectory"
     unauthenticated_client_action = "RedirectToLoginPage"


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-WEB-008 

 **Violation Description:** 

 This policy will identify the Azure app service which dont have detaild error message enabled and give alert 

 **How to Fix:** 

 In 'azurerm_app_service' resource, set 'detailed_error_messages_enabled = true' under 'logs' block to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service#detailed_error_messages_enabled' target='_blank'>here</a> for details.