### PR TITLE
Fixed PR-AZR-TRF-WEB-017: Azure App Service storage account type should be AzureFiles

### DIFF
--- a/azure/functionapp/main.tf
+++ b/azure/functionapp/main.tf
@@ -19,9 +19,9 @@ resource "azurerm_app_service" "example" {
 
   site_config {
     dotnet_framework_version = "v4.0"
-    php_version = 7.1
-    python_version = 3.6
-    java_version = "1.7.0_80"
+    php_version              = 7.1
+    python_version           = 3.6
+    java_version             = "1.7.0_80"
     scm_type                 = "LocalGit"
     min_tls_version          = 1.1
     remote_debugging_enabled = true
@@ -55,11 +55,11 @@ resource "azurerm_app_service" "example" {
   }
 
   storage_account {
-    name = ""
-    type = ""
-    account_name = ""
-    share_name = ""
-    access_key = ""
+    name         = "String<The name of the storage account identifier>"
+    type         = "AzureFiles"
+    account_name = "String<The name of the storage account.>"
+    share_name   = "String<The name of the file share (container name, for Blob storage.>"
+    access_key   = "String<The access key for the storage account>"
   }
 }
 
@@ -85,7 +85,7 @@ resource "azurerm_function_app" "example" {
   storage_account_access_key = azurerm_storage_account.example.primary_access_key
   os_type                    = "linux"
   version                    = "~3"
- auth_settings {
+  auth_settings {
     enabled                       = false
     default_provider              = "AzureActiveDirectory"
     unauthenticated_client_action = "RedirectToLoginPage"


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-WEB-017 

 **Violation Description:** 

 This policy will identify the Azure app service which dont have storage account type AzureFiles and give alert 

 **How to Fix:** 

 In 'azurerm_app_service' resource, set type = 'AzureFiles' under 'storage_account' block to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service#storage_account' target='_blank'>here</a> for details.