### PR TITLE
Fixed PR-AZR-TRF-NSG-001: Azure Network Security Group (NSG) having Inbound rule overly permissive to all TCP traffic from any source

### DIFF
--- a/azure/nsg/terraform.tfvars
+++ b/azure/nsg/terraform.tfvars
@@ -1,20 +1,20 @@
-location             = "eastus2"
-resource_group_name  = "prancer-test-rg"
+location            = "eastus2"
+resource_group_name = "prancer-test-rg"
 
-nsg_name             = "prancer-nsg"
+nsg_name = "prancer-nsg"
 
-names                = [
+names = [
   "allow-all-tcp",
   "allow-port-range",
   "allow-all-udp"
 ]
-priorities           = [100, 101, 102, 103, 104, 105, 106]
-directions           = ["Inbound", "Inbound", "Outbound", "Inbound", "Inbound", "Inbound", "Inbound"]
-accesses             = ["Allow", "Allow", "Allow", "Allow", "Allow", "Allow", "Allow"]
-protocols            = ["Tcp", "Tcp", "Udp", "Tcp", "Udp", "*", "Icmp"]
-src_ports            = ["*", "*", "*", "*", "*", "*", "*"]
-dst_ports            = ["*", "20-6000", "*", "*", "*", "*", "*"]
-src_addresses        = ["*", "Internet", "Internet", "Internet", "Internet", "Internet", "Internet"]
-dst_addresses        = ["*", "*", "*", "*", "*", "*", "*"]
+priorities    = [100, 101, 102, 103, 104, 105, 106]
+directions    = ["Inbound", "Inbound", "Outbound", "Inbound", "Inbound", "Inbound", "Inbound"]
+accesses      = ["Deny", "Allow", "Allow", "Allow", "Allow", "Allow", "Allow"]
+protocols     = ["Tcp", "Tcp", "Udp", "Tcp", "Udp", "*", "Icmp"]
+src_ports     = ["*", "*", "*", "*", "*", "*", "*"]
+dst_ports     = ["*", "20-6000", "*", "*", "*", "*", "*"]
+src_addresses = ["*", "Internet", "Internet", "Internet", "Internet", "Internet", "Internet"]
+dst_addresses = ["*", "*", "*", "*", "*", "*", "*"]
 
-tags                 = {}
+tags = {}


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-NSG-001 

 **Violation Description:** 

 This policy identifies Azure Network Security Groups (NSGs) which are overly permissive to open TCP traffic from any source. A network security group contains a list of security rules that allow or deny inbound or outbound network traffic based on source or destination IP address, port, and protocol. As a best practice, it is recommended to configure NSGs to restrict traffic from known sources, allowing only authorized protocols and ports. 

 **How to Fix:** 

 