### PR TITLE
Fixed PR-AZR-TRF-NSG-014: Azure Network Security Group should not allow SSH traffic from internet on port 22

### DIFF
--- a/azure/nsg/terraform.tfvars
+++ b/azure/nsg/terraform.tfvars
@@ -1,20 +1,20 @@
-location             = "eastus2"
-resource_group_name  = "prancer-test-rg"
+location            = "eastus2"
+resource_group_name = "prancer-test-rg"
 
-nsg_name             = "prancer-nsg"
+nsg_name = "prancer-nsg"
 
-names                = [
+names = [
   "allow-all-tcp",
   "allow-port-range",
   "allow-all-udp"
 ]
-priorities           = [100, 101, 102, 103, 104, 105, 106]
-directions           = ["Inbound", "Inbound", "Outbound", "Inbound", "Inbound", "Inbound", "Inbound"]
-accesses             = ["Allow", "Allow", "Allow", "Allow", "Allow", "Allow", "Allow"]
-protocols            = ["Tcp", "Tcp", "Udp", "Tcp", "Udp", "*", "Icmp"]
-src_ports            = ["*", "*", "*", "*", "*", "*", "*"]
-dst_ports            = ["*", "20-6000", "*", "*", "*", "*", "*"]
-src_addresses        = ["*", "Internet", "Internet", "Internet", "Internet", "Internet", "Internet"]
-dst_addresses        = ["*", "*", "*", "*", "*", "*", "*"]
+priorities    = [100, 101, 102, 103, 104, 105, 106]
+directions    = ["Inbound", "Inbound", "Outbound", "Inbound", "Inbound", "Inbound", "Inbound"]
+accesses      = ["Deny", "Deny", "Allow", "Allow", "Allow", "Allow", "Allow"]
+protocols     = ["Tcp", "Tcp", "Udp", "Tcp", "Udp", "*", "Icmp"]
+src_ports     = ["*", "*", "*", "*", "*", "*", "*"]
+dst_ports     = ["*", "20-6000", "*", "*", "*", "*", "*"]
+src_addresses = ["*", "Internet", "Internet", "Internet", "Internet", "Internet", "Internet"]
+dst_addresses = ["*", "*", "*", "*", "*", "*", "*"]
 
-tags                 = {}
+tags = {}


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-NSG-014 

 **Violation Description:** 

 Blocking SSH port 22 will protect users from attacks like Account compromise. 

 **How to Fix:** 

 In 'azurerm_network_security_rule' resource, make sure property 'destination_port_range' dont have port '22' to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule#destination_port_range' target='_blank'>here</a> for details.