### PR TITLE
Fixed PR-AZR-TRF-NSG-033: Azure Network Security Group should not allow NetBIOS (UDP Port 137)

### DIFF
--- a/azure/nsg/terraform.tfvars
+++ b/azure/nsg/terraform.tfvars
@@ -1,20 +1,20 @@
-location             = "eastus2"
-resource_group_name  = "prancer-test-rg"
+location            = "eastus2"
+resource_group_name = "prancer-test-rg"
 
-nsg_name             = "prancer-nsg"
+nsg_name = "prancer-nsg"
 
-names                = [
+names = [
   "allow-all-tcp",
   "allow-port-range",
   "allow-all-udp"
 ]
-priorities           = [100, 101, 102, 103, 104, 105, 106]
-directions           = ["Inbound", "Inbound", "Outbound", "Inbound", "Inbound", "Inbound", "Inbound"]
-accesses             = ["Allow", "Allow", "Allow", "Allow", "Allow", "Allow", "Allow"]
-protocols            = ["Tcp", "Tcp", "Udp", "Tcp", "Udp", "*", "Icmp"]
-src_ports            = ["*", "*", "*", "*", "*", "*", "*"]
-dst_ports            = ["*", "20-6000", "*", "*", "*", "*", "*"]
-src_addresses        = ["*", "Internet", "Internet", "Internet", "Internet", "Internet", "Internet"]
-dst_addresses        = ["*", "*", "*", "*", "*", "*", "*"]
+priorities    = [100, 101, 102, 103, 104, 105, 106]
+directions    = ["Inbound", "Inbound", "Outbound", "Inbound", "Inbound", "Inbound", "Inbound"]
+accesses      = ["Deny", "Deny", "Allow", "Allow", "Allow", "Allow", "Allow"]
+protocols     = ["Tcp", "Tcp", "Udp", "Tcp", "Udp", "*", "Icmp"]
+src_ports     = ["*", "*", "*", "*", "*", "*", "*"]
+dst_ports     = ["*", "20-6000", "*", "*", "*", "*", "*"]
+src_addresses = ["*", "Internet", "Internet", "Internet", "Internet", "Internet", "Internet"]
+dst_addresses = ["*", "*", "*", "*", "*", "*", "*"]
 
-tags                 = {}
+tags = {}


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-NSG-033 

 **Violation Description:** 

 This policy detects any NSG rule that allows NetBIOS traffic on UDP port 137 from the internet. Review your list of NSG rules to ensure that your resources are not exposed.<br>As a best practice, restrict NetBIOS solely to known static IP addresses. Limit the access list to include known hosts, services, or specific employees only. 

 **How to Fix:** 

 In 'azurerm_network_security_rule' resource, make sure property 'destination_port_range' dont have port '137' to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule#destination_port_range' target='_blank'>here</a> for details.