### PR TITLE
Fixed PR-AZR-TRF-NSG-009: Azure Network Security Group allows FTP (TCP Port 21)

### DIFF
--- a/azure/nsg/terraform.tfvars
+++ b/azure/nsg/terraform.tfvars
@@ -1,9 +1,9 @@
-location             = "eastus2"
-resource_group_name  = "prancer-test-rg"
+location            = "eastus2"
+resource_group_name = "prancer-test-rg"
 
-nsg_name             = "prancer-nsg"
+nsg_name = "prancer-nsg"
 
-names                = [
+names = [
   "allow-all-tcp",
   "allow-port-range",
   "allow-all-udp",
@@ -12,13 +12,13 @@ names                = [
   "allow-all-inbound",
   "allow-all-inbound-icmp"
 ]
-priorities           = [100, 101, 102, 103, 104, 105, 106]
-directions           = ["Inbound", "Inbound", "Outbound", "Inbound", "Inbound", "Inbound", "Inbound"]
-accesses             = ["Allow", "Allow", "Allow", "Allow", "Allow", "Allow", "Allow"]
-protocols            = ["Tcp", "Tcp", "Udp", "Tcp", "Udp", "*", "Icmp"]
-src_ports            = ["*", "*", "*", "*", "*", "*", "*"]
-dst_ports            = ["*", "20-6000", "*", "*", "*", "*", "*"]
-src_addresses        = ["*", "Internet", "Internet", "Internet", "Internet", "Internet", "Internet"]
-dst_addresses        = ["*", "*", "*", "*", "*", "*", "*"]
+priorities    = [100, 101, 102, 103, 104, 105, 106]
+directions    = ["Inbound", "Inbound", "Outbound", "Inbound", "Inbound", "Inbound", "Inbound"]
+accesses      = ["Deny", "Deny", "Allow", "Deny", "Allow", "Allow", "Allow"]
+protocols     = ["Tcp", "Tcp", "Udp", "Tcp", "Udp", "*", "Icmp"]
+src_ports     = ["*", "*", "*", "*", "*", "*", "*"]
+dst_ports     = ["*", "20-6000", "*", "*", "*", "*", "*"]
+src_addresses = ["*", "Internet", "Internet", "Internet", "Internet", "Internet", "Internet"]
+dst_addresses = ["*", "*", "*", "*", "*", "*", "*"]
 
-tags                 = {}
+tags = {}


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-NSG-009 

 **Violation Description:** 

 This policy detects any NSG rule that allows FTP traffic on TCP port 21 from the internet. Review your list of NSG rules to ensure that your resources are not exposed.<br>As a best practice, restrict FTP solely to known static IP addresses. Limit the access list to include known hosts, services, or specific employees only. 

 **How to Fix:** 

 