### PR TITLE
Fixed PR-AZR-TRF-NET-004: Azure virtual network peering state should be connected

### DIFF
--- a/azure/vnetpeerings/terraform.tfvars
+++ b/azure/vnetpeerings/terraform.tfvars
@@ -1,21 +1,21 @@
-location              = "eastus2"
-resource_group        = "prancer-test-rg"
+location       = "eastus2"
+resource_group = "prancer-test-rg"
 
-peer1_vnet            = "peer1"
-peer2_vnet            = "peer2"
+peer1_vnet = "peer1"
+peer2_vnet = "peer2"
 
-peer1_address_space         = "10.154.0.0/16"
-peer1_dns_server            = "10.154.0.1"
-peer2_address_space         = "10.254.0.0/16"
-peer2_dns_server            = "10.254.0.1"
+peer1_address_space = "10.154.0.0/16"
+peer1_dns_server    = "10.154.0.1"
+peer2_address_space = "10.254.0.0/16"
+peer2_dns_server    = "10.254.0.1"
 
 peering_name                  = "prancer-vnet-peering"
 allow_virtual_network_access1 = false
 allow_forwarded_traffic1      = true
 allow_gateway_transit1        = false
-allow_virtual_network_access2 = false
+allow_virtual_network_access2 = true
 allow_forwarded_traffic2      = true
 allow_gateway_transit2        = false
 
-tags                  = {}
+tags = {}
 


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-NET-004 

 **Violation Description:** 

 Virtual network peering enables you to connect two Azure virtual networks so that the resources in these networks are directly connected.<br><br>This policy identifies Azure virtual network peers that are disconnected. Typically, the disconnection happens when a peering configuration is deleted on one virtual network, and the other virtual network reports the peering status as disconnected. 

 **How to Fix:** 

 In 'azurerm_virtual_network_peering' resource, set 'allow_virtual_network_access = true' or remove 'allow_virtual_network_access' property to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering#allow_virtual_network_access' target='_blank'>here</a> for details.