### PR TITLE
Fixed PR-AWS-TRF-ECS-009: Ensure ECS Services and Task Set enable_execute_command property set to False

### DIFF
--- a/aws/modules/ecs/main.tf
+++ b/aws/modules/ecs/main.tf
@@ -16,7 +16,7 @@ resource "aws_ecs_service" "mongo" {
   desired_count          = 3
   iam_role               = aws_iam_role.foo.arn
   depends_on             = [aws_iam_role_policy.foo]
-  enable_execute_command = true
+  enable_execute_command = false
   launch_type            = "EC2"
 
   ordered_placement_strategy {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-ECS-009 

 **Violation Description:** 

 If the enable_execute_command property is set to True on an ECS Service then any third person can launch ECS service into an unsafe configuration allowing for external exposure or unaccounted for configurations. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented at this URL: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#enable_execute_command