### PR TITLE
Fixed PR-AWS-TRF-ELB-018: Ensure all load balancers created are application load balancers

### DIFF
--- a/aws/modules/elb/main.tf
+++ b/aws/modules/elb/main.tf
@@ -58,7 +58,7 @@ data "aws_acm_certificate" "example" {
 resource "aws_lb" "test" {
   name               = "test-lb-tf"
   internal           = true
-  load_balancer_type = "network"
+  load_balancer_type = "application"
   security_groups    = []
   target_type        = "instance"
 


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-ELB-018 

 **Violation Description:** 

 Ensure the value of Type for each LoadBalancer resource is application or the Type is not set, since it defaults to application 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented at this URL: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb