### PR TITLE
Fixed PR-AWS-TRF-ELB-019: Ensure LoadBalancer TargetGroup protocol values are limited to HTTPS

### DIFF
--- a/aws/modules/ecs/main.tf
+++ b/aws/modules/ecs/main.tf
@@ -51,7 +51,7 @@ data "aws_ecs_service" "example" {
 resource "aws_lb_target_group" "foo" {
   name        = "tf-example-lb-tg"
   port        = 80
-  protocol    = "HTTP"
+  protocol    = "HTTPS"
   vpc_id      = aws_vpc.main.id
   target_type = "instance"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-ELB-019 

 **Violation Description:** 

 The only allowed protocol value for LoadBalancer TargetGroups is HTTPS, though the property is ignored if the target type is lambda. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented at this URL: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group