### PR TITLE
Fixed PR-AWS-TRF-ECS-014: Ensure that ECS Task Definition have their network mode property set to awsvpc

### DIFF
--- a/aws/ecs/terraform.tfvars
+++ b/aws/ecs/terraform.tfvars
@@ -4,11 +4,11 @@ enable_container_insights = false
 family             = "prancer-task"
 task_role_arn      = null
 execution_role_arn = ""
-network_mode       = "bridge"
+network_mode       = "awsvpc"
 cpu                = 256
 memory             = 1024
 
-tags                      = {
+tags = {
   environment = "Production"
-  project = "Prancer"
+  project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-ECS-014 

 **Violation Description:** 

 Ensure that ECS Task Definition have their network mode property set to awsvpc. else an Actor can launch ECS service into an unsafe configuration allowing for external exposure or unaccounted for configurations 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented at this URL: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition#network_mode