### PR TITLE
Fixed PR-AWS-TRF-CT-002: AWS CloudTrail log validation is not enabled in all regions

### DIFF
--- a/aws/cloudtrail/terraform.tfvars
+++ b/aws/cloudtrail/terraform.tfvars
@@ -23,19 +23,19 @@ expire_noncurrent_versions                      = true
 lifecycle_days_to_expiration                    = 365
 server_side_encryption_configuration            = []
 
-name                            = "prancer-ct"
-s3_key_prefix                   = "prefix"
-enable_logging                  = true
-enable_log_file_validation      = false
-is_multi_region_trail           = false
-include_global_service_events   = true
-cloud_watch_logs_role_arn       = ""
-cloud_watch_logs_group_arn      = ""
-kms_key_arn                     = ""
-is_organization_trail           = false
-event_selector                  = []
+name                          = "prancer-ct"
+s3_key_prefix                 = "prefix"
+enable_logging                = true
+enable_log_file_validation    = true
+is_multi_region_trail         = false
+include_global_service_events = true
+cloud_watch_logs_role_arn     = ""
+cloud_watch_logs_group_arn    = ""
+kms_key_arn                   = ""
+is_organization_trail         = false
+event_selector                = []
 
 tags = {
   Environment = "Production"
-  Project = "Prancer"
+  Project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-CT-002 

 **Violation Description:** 

 This policy identifies AWS CloudTrails in which log validation is not enabled in all regions. CloudTrail log file validation creates a digitally signed digest file containing a hash of each log that CloudTrail writes to S3. These digest files can be used to determine whether a log file was modified after CloudTrail delivered the log. It is recommended that file validation be enabled on all CloudTrails. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented at this URL: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail