### PR TITLE
Fixed PR-AWS-TRF-CT-001: AWS CloudTrail is not enabled in all regions

### DIFF
--- a/aws/cloudtrail/terraform.tfvars
+++ b/aws/cloudtrail/terraform.tfvars
@@ -23,19 +23,19 @@ expire_noncurrent_versions                      = true
 lifecycle_days_to_expiration                    = 365
 server_side_encryption_configuration            = []
 
-name                            = "prancer-ct"
-s3_key_prefix                   = "prefix"
-enable_logging                  = true
-enable_log_file_validation      = false
-is_multi_region_trail           = false
-include_global_service_events   = true
-cloud_watch_logs_role_arn       = ""
-cloud_watch_logs_group_arn      = ""
-kms_key_arn                     = ""
-is_organization_trail           = false
-event_selector                  = []
+name                          = "prancer-ct"
+s3_key_prefix                 = "prefix"
+enable_logging                = true
+enable_log_file_validation    = false
+is_multi_region_trail         = true
+include_global_service_events = true
+cloud_watch_logs_role_arn     = ""
+cloud_watch_logs_group_arn    = ""
+kms_key_arn                   = ""
+is_organization_trail         = false
+event_selector                = []
 
 tags = {
   Environment = "Production"
-  Project = "Prancer"
+  Project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-CT-001 

 **Violation Description:** 

 Checks to ensure that CloudTrail is enabled across all regions. AWS CloudTrail is a service that enables governance, compliance, operational PR-AWS-TRF-CT-001-DESC risk auditing of the AWS account. It is a compliance and security best practice to turn on CloudTrail across different regions to get a complete audit trail of activities across various services. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented at this URL: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail