### PR TITLE
Fixed PR-AZR-TRF-MNT-013: Activity log audit profile should configure to capture all the activities

### DIFF
--- a/azure/modules/storageAccount/main.tf
+++ b/azure/modules/storageAccount/main.tf
@@ -19,7 +19,7 @@ resource "azurerm_monitor_activity_log_alert" "main" {
   resource_group_name = azurerm_resource_group.main.name
   scopes              = [azurerm_resource_group.main.id]
   description         = "This alert will monitor a specific storage account updates."
-  enabled = false 
+  enabled             = false
   criteria {
     resource_id    = azurerm_storage_account.storageAccount[0].id
     operation_name = "Microsoft.Storage/storageAccounts/write"
@@ -30,10 +30,7 @@ resource "azurerm_monitor_activity_log_alert" "main" {
 resource "azurerm_monitor_log_profile" "example" {
   name = "default"
 
-  categories = [
-    "Action",
-    "Write",
-  ]
+  categories = ["Action", "Delete", "Write"]
 
   locations = [
     "westus",


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-MNT-013 

 **Violation Description:** 

 This policy identifies azurerm_monitor_log_profile which dont capture all type of activities. Activity Logs can be used to check for anomalies and gives insight into suspected breaches or misuse of information and access. 

 **How to Fix:** 

 In 'azurerm_monitor_log_profile' resource, make sure 'categories' array exist and contains at least ['Action','Delete','Write'] as value to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_log_profile#categories' target='_blank'>here</a> for details.