### PR TITLE
Fixed PR-AWS-TRF-CFG-001: AWS Config must record all possible resources

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -218,6 +218,11 @@ STACK
 resource "aws_config_configuration_recorder" "foo" {
   name     = "example"
   role_arn = aws_iam_role.r.arn
+
+  recording_group {
+    all_supported                 = true
+    include_global_resource_types = true
+  }
 }
 
 resource "aws_iam_role" "r" {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-CFG-001 

 **Violation Description:** 

 This policy identifies resources for which AWS Config recording is enabled but recording for all possible resources are disabled. AWS Config provides an inventory of your AWS resources and a history of configuration changes to these resources. You can use AWS Config to define rules that evaluate these configurations for compliance. Hence, it is important to enable this feature. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented at this URL: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-configurationrecorder.html