### PR TITLE
Fixed PR-AWS-TRF-KMS-002: AWS KMS Customer Managed Key not in use

### DIFF
--- a/aws/msk/main.tf
+++ b/aws/msk/main.tf
@@ -30,6 +30,7 @@ resource "aws_security_group" "sg" {
 
 resource "aws_kms_key" "kms" {
   description = "example"
+  is_enabled  = true
 }
 
 resource "aws_cloudwatch_log_group" "test" {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-KMS-002 

 **Violation Description:** 

 This policy identifies KMS Customer Managed Keys(CMKs) which are not usable. When you create a CMK, it is enabled by default. If you disable a CMK or schedule it for deletion makes it unusable, it cannot be used to encrypt or decrypt data and AWS KMS does not rotate the backing keys until you re-enable it. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key' target='_blank'>here</a>