### PR TITLE
Fixed PR-AWS-TRF-AG-003: AWS API gateway request authorization is not set

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -474,6 +474,7 @@ resource "aws_api_gateway_authorizer" "demo" {
   rest_api_id            = aws_api_gateway_rest_api.demo.id
   authorizer_uri         = aws_lambda_function.authorizer.invoke_arn
   authorizer_credentials = aws_iam_role.invocation_role.arn
+  type                   = "REQUEST"
 }
 
 resource "aws_api_gateway_rest_api" "demo" {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-AG-003 

 **Violation Description:** 

 This policy identifies AWS API Gateways of protocol type REST for which the request authorisation is not set. The method request for API gateways takes the client input that is passed to the back end through the integration request. It is recommended to add authorization type to each of the method to add a layer of protection. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_authorizer' target='_blank'>here</a>