### PR TITLE
Fixed PR-AWS-TRF-KMS-001: AWS Customer Master Key (CMK) rotation is not enabled

### DIFF
--- a/aws/msk/main.tf
+++ b/aws/msk/main.tf
@@ -29,7 +29,8 @@ resource "aws_security_group" "sg" {
 }
 
 resource "aws_kms_key" "kms" {
-  description = "example"
+  description         = "example"
+  enable_key_rotation = true
 }
 
 resource "aws_cloudwatch_log_group" "test" {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-KMS-001 

 **Violation Description:** 

 This policy identifies Customer Master Keys (CMKs) that are not enabled with key rotation. AWS KMS (Key Management Service) allows customers to create master keys to encrypt sensitive data in different services. As a security best practice, it is important to rotate the keys periodically so that if the keys are compromised, the data in the underlying service is still secure with the new keys. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key' target='_blank'>here</a>