### PR TITLE
Fixed PR-AZR-TRF-MNT-001: Activity log alerts should be enabled

### DIFF
--- a/azure/modules/storageAccount/main.tf
+++ b/azure/modules/storageAccount/main.tf
@@ -19,7 +19,7 @@ resource "azurerm_monitor_activity_log_alert" "main" {
   resource_group_name = azurerm_resource_group.main.name
   scopes              = [azurerm_resource_group.main.id]
   description         = "This alert will monitor a specific storage account updates."
-  enabled = false 
+  enabled             = true
   criteria {
     resource_id    = azurerm_storage_account.storageAccount[0].id
     operation_name = "Microsoft.Storage/storageAccounts/write"


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-MNT-001 

 **Violation Description:** 

 Activity log alerts are alerts that activate when a new activity log event occurs that matches the conditions specified in the alert. Based on the order and volume of the events recorded in Azure activity log, the alert rule will fire. Enabling Activity log alerts will allow Azure to send you emails about any high severity alerts in your environment. This will make sure that you are aware of any security issues and take prompt actions to mitigate the risks. 

 **How to Fix:** 

 In 'azurerm_monitor_activity_log_alert' resource, set 'enabled = true' to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_activity_log_alert#enabled' target='_blank'>here</a> for details.