### PR TITLE
Fixed PR-AZR-TRF-MNT-009: Ensure Activity log profile retention is set to 365 days or greater

### DIFF
--- a/azure/modules/storageAccount/main.tf
+++ b/azure/modules/storageAccount/main.tf
@@ -19,7 +19,7 @@ resource "azurerm_monitor_activity_log_alert" "main" {
   resource_group_name = azurerm_resource_group.main.name
   scopes              = [azurerm_resource_group.main.id]
   description         = "This alert will monitor a specific storage account updates."
-  enabled = false 
+  enabled             = false
   criteria {
     resource_id    = azurerm_storage_account.storageAccount[0].id
     operation_name = "Microsoft.Storage/storageAccounts/write"
@@ -42,6 +42,6 @@ resource "azurerm_monitor_log_profile" "example" {
   storage_account_id = azurerm_storage_account.storageAccount[0].id
   retention_policy {
     enabled = false
-    days    = 7
+    days    = 365
   }
 }


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-MNT-009 

 **Violation Description:** 

 This policy identifies azurerm_monitor_log_profile which have log retention less than 365 days. Activity Logs can be used to check for anomalies and gives insight into suspected breaches or misuse of information and access. 

 **How to Fix:** 

 In 'azurerm_monitor_log_profile' resource, set days = '365' under 'retention_policy' block to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_log_profile#days' target='_blank'>here</a> for details.