### PR TITLE
Fixed PR-AZR-TRF-MNT-010: Activity log profile retention should be enabled

### DIFF
--- a/azure/modules/storageAccount/main.tf
+++ b/azure/modules/storageAccount/main.tf
@@ -19,7 +19,7 @@ resource "azurerm_monitor_activity_log_alert" "main" {
   resource_group_name = azurerm_resource_group.main.name
   scopes              = [azurerm_resource_group.main.id]
   description         = "This alert will monitor a specific storage account updates."
-  enabled = false 
+  enabled             = false
   criteria {
     resource_id    = azurerm_storage_account.storageAccount[0].id
     operation_name = "Microsoft.Storage/storageAccounts/write"
@@ -41,7 +41,7 @@ resource "azurerm_monitor_log_profile" "example" {
   ]
   storage_account_id = azurerm_storage_account.storageAccount[0].id
   retention_policy {
-    enabled = false
+    enabled = true
     days    = 7
   }
 }


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-MNT-010 

 **Violation Description:** 

 This policy identifies azurerm_monitor_log_profile which dont have log retention enabled. Activity Logs can be used to check for anomalies and gives insight into suspected breaches or misuse of information and access. 

 **How to Fix:** 

 In 'azurerm_monitor_log_profile' resource, set 'enabled = true' under 'retention_policy' block to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_log_profile#enabled' target='_blank'>here</a> for details.