### PR TITLE
Fixed PR-AZR-TRF-AKS-006: Azure AKS role-based access control (RBAC) should be enforced

### DIFF
--- a/azure/modules/managedClusters/main.tf
+++ b/azure/modules/managedClusters/main.tf
@@ -17,7 +17,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
 
   role_based_access_control {
     azure_active_directory {
-      managed = var.aad_managed
+      managed            = var.aad_managed
       azure_rbac_enabled = var.aad_managed_azure_rbac_enabled
     }
     enabled = var.rbac_enabled
@@ -42,5 +42,8 @@ resource "azurerm_kubernetes_cluster" "aks" {
     type = var.aks_identity_type
   }
 
-  tags = var.tags
+  tags          = var.tags
+  add_blocks    = []
+  block_type    = "role_based_access_control"
+  block_indexes = [1]
 }


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-AKS-006 

 **Violation Description:** 

 Azure Kubernetes Service (AKS) can be configured to use Azure Active Directory (AD) for user authentication. In this configuration, you sign in to an AKS cluster using an Azure AD authentication token. You can also configure Kubernetes role-based access control (Kubernetes RBAC) to limit access to cluster resources based a user's identity or group membership. This policy checks your AKS cluster Azure Active Directory (AD) RBAC setting and alerts if disabled. 

 **How to Fix:** 

 In 'azurerm_kubernetes_cluster' resource, set role_based_access_control.azure_active_directory.managed = true to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#role_based_access_control' target='_blank'>here</a> for details.