### PR TITLE
Fixed PR-AZR-TRF-AGW-003: Ensure Application Gateway is using Https protocol

### DIFF
--- a/azure/applicationgateways/terraform.tfvars
+++ b/azure/applicationgateways/terraform.tfvars
@@ -1,19 +1,19 @@
-location              = "eastus2"
-vnet_name             = "prancer-vnet"
-resource_group        = "prancer-test-rg"
-address_space         = "10.254.0.0/16"
-dns_server            = "10.254.0.1"
+location       = "eastus2"
+vnet_name      = "prancer-vnet"
+resource_group = "prancer-test-rg"
+address_space  = "10.254.0.0/16"
+dns_server     = "10.254.0.1"
 
-subnet_name_fe        = "prancer-frontend"
-address_prefixes_fe   = ["10.254.0.0/24"]
+subnet_name_fe      = "prancer-frontend"
+address_prefixes_fe = ["10.254.0.0/24"]
 
-subnet_name_be        = "prancer-backend"
-address_prefixes_be   = ["10.254.2.0/24"]
+subnet_name_be      = "prancer-backend"
+address_prefixes_be = ["10.254.2.0/24"]
 
-pip_name              = "prancer-pip"
-pip_type              = "Dynamic"
-pip_sku               = "Basic"
-ip_version            = "IPv4"
+pip_name   = "prancer-pip"
+pip_type   = "Dynamic"
+pip_sku    = "Basic"
+ip_version = "IPv4"
 
 app_gw_name            = "prancer-app-gw"
 app_gw_sku             = "WAF_Medium"
@@ -26,7 +26,7 @@ app_gw_be_http_path    = "/login/"
 app_gw_be_http_port    = "80"
 app_gw_be_http_proto   = "Http"
 app_gw_be_http_timeout = "60"
-app_gw_listener_proto  = "Http"
+app_gw_listener_proto  = "Https"
 app_gw_req_route_type  = "Basic"
 min_protocol_version   = "TLSv1_0"
 waf_enabled            = false
@@ -34,7 +34,7 @@ waf_firewall_mode      = "Detection"
 waf_rule_set_type      = "OWASP"
 waf_rule_set_version   = "2.2.9"
 
-tags                   = {
+tags = {
   environment = "Production"
   project     = "Prancer"
 }

--- a/azure/applicationgateways/vars.tf
+++ b/azure/applicationgateways/vars.tf
@@ -22,7 +22,8 @@ variable "app_gw_be_http_path" {}
 variable "app_gw_be_http_port" {}
 variable "app_gw_be_http_proto" {}
 variable "app_gw_be_http_timeout" {}
-variable "app_gw_listener_proto" {}
+variable "app_gw_listener_proto" { default = "Https"
+}
 variable "app_gw_req_route_type" {}
 variable "min_protocol_version" {}
 variable "waf_enabled" {}

--- a/azure/modules/applicationGateway/vars.tf
+++ b/azure/modules/applicationGateway/vars.tf
@@ -13,7 +13,8 @@ variable "app_gw_be_http_port" {}
 variable "app_gw_be_http_proto" {}
 variable "app_gw_be_http_timeout" {}
 variable "app_gw_ip" {}
-variable "app_gw_listener_proto" {}
+variable "app_gw_listener_proto" { default = "Https"
+}
 variable "app_gw_req_route_type" {}
 variable "min_protocol_version" {}
 variable "waf_enabled" {}


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-AGW-003 

 **Violation Description:** 

 Application Gateway allows to set network protocols Http and Https. It is highly recommended to use Https protocol for secure connections. 

 **How to Fix:** 

 In 'azurerm_application_gateway' resource, set protocol = 'https' under 'http_listener' block to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_gateway#protocol' target='_blank'>here</a> for details.