### PR TITLE
Fixed PR-AZR-TRF-AGW-004: Ensure Application Gateway frontendIPConfigurations does not have public ip configured

### DIFF
--- a/azure/modules/applicationGateway/main.tf
+++ b/azure/modules/applicationGateway/main.tf
@@ -27,8 +27,7 @@ resource "azurerm_application_gateway" "appgw" {
   }
 
   frontend_ip_configuration {
-    name                 = "${var.app_gw_name}-fe-ip"
-    public_ip_address_id = azurerm_public_ip.example.id
+    name = "${var.app_gw_name}-fe-ip"
   }
 
   backend_address_pool {
@@ -69,7 +68,7 @@ resource "azurerm_application_gateway" "appgw" {
     rule_set_type    = var.waf_rule_set_type
     rule_set_version = var.waf_rule_set_version
   }
-  
+
 }
 
 resource "azurerm_application_gateway" "appgw2" {
@@ -94,8 +93,7 @@ resource "azurerm_application_gateway" "appgw2" {
   }
 
   frontend_ip_configuration {
-    name                 = "${var.app_gw_name}-fe-ip"
-    public_ip_address_id = azurerm_public_ip.example.id
+    name = "${var.app_gw_name}-fe-ip"
   }
 
   backend_address_pool {
@@ -131,7 +129,7 @@ resource "azurerm_application_gateway" "appgw2" {
   }
 
   firewall_policy_id = azurerm_web_application_firewall_policy.testfwp.id
-  
+
 }
 
 resource "azurerm_web_application_firewall_policy" "testfwp" {


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-AGW-004 

 **Violation Description:** 

 Application Gateway allows to set public or private ip in frontendIPConfigurations. It is highly recommended to only configure private ip in frontendIPConfigurations. 

 **How to Fix:** 

 For resource type 'azurerm_application_gateway' make sure 'public_ip_address_id' does not exist under 'frontend_ip_configuration' to fix the issue. Please visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_gateway#frontend_ip_configuration' target='_blank'>here</a> for details.