### PR TITLE
Fixed PR-AZR-TRF-KV-003: Key vault should have purge protection enabled

### DIFF
--- a/azure/vault/main.tf
+++ b/azure/vault/main.tf
@@ -17,6 +17,7 @@ resource "azurerm_key_vault" "example" {
     tenant_id = data.azurerm_client_config.current.tenant_id
     object_id = data.azurerm_client_config.current.object_id
   }
+  purge_protection_enabled = true
 }
 
 resource "azurerm_key_vault_secret" "example" {


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-KV-003 

 **Violation Description:** 

 The key vault contains object keys, secrets and certificates. Accidental unavailability of a key vault can cause immediate data loss or loss of security functions (authentication, validation, verification, non-repudiation 

 **How to Fix:** 

 In 'azurerm_key_vault' resource, set 'purge_protection_enabled = true' to fix the issue. Please visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault#purge_protection_enabled' target='_blank'>here</a> for details.