### PR TITLE
Fixed PR-AZR-TRF-KV-005: Azure Key Vault secrets should have an expiration date

### DIFF
--- a/azure/keyvaultsecret/terraform.tfvars
+++ b/azure/keyvaultsecret/terraform.tfvars
@@ -1,17 +1,17 @@
-location                    = "eastus2"
-resource_group              = "prancer-test-rg"
+location       = "eastus2"
+resource_group = "prancer-test-rg"
 
-storage_count               = 1
-storage_name                = "prancerstorageaccount007"
-accountTier                 = "Standard"
-replicationType             = "LRS"
-enableSecureTransfer        = false
+storage_count        = 1
+storage_name         = "prancerstorageaccount007"
+accountTier          = "Standard"
+replicationType      = "LRS"
+enableSecureTransfer = false
 
-kv_name                     = "prancer-key-vault-t3st"
-kv_sku                      = "standard"
+kv_name = "prancer-key-vault-t3st"
+kv_sku  = "standard"
 
-kv_secret_name              = "prancer-secret"
-kv_secret_value             = "53cr3t"
-expiration_date             = null
+kv_secret_name  = "prancer-secret"
+kv_secret_value = "53cr3t"
+expiration_date = "String<Expiration UTC datetime (Y-m-d'T'H:M:S'Z')>"
 
-tags                        = {}
+tags = {}


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-KV-005 

 **Violation Description:** 

 This policy identifies Azure Key Vault secrets that do not have an expiry date. As a best practice, set an expiration date for each secret and rotate the secret regularly.<br><br>Before you activate this policy, ensure that you have added the <compliance-software> Service Principal to each Key Vault: https://docs.paloaltonetworks.com/<compliance-software>/<compliance-software>-admin/connect-your-cloud-platform-to-<compliance-software>/onboard-your-azure-account/set-up-your-azure-account.html<br><br>Alternatively, run the following command on the Azure cloud shell:<br>az keyvault list | jq '.[].name' | xargs -I {} az keyvault set-policy --name {} --certificate-permissions list listissuers --key-permissions list --secret-permissions list --spn <<compliance-software>_app_id> 

 **How to Fix:** 

 In 'azurerm_key_vault_secret' resource, set valid date other then null in property 'expiration_date' to fix the issue. please visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret#expiration_date' target='_blank'>here</a> for details.