### PR TITLE
Fixed PR-AZR-TRF-KV-005: Azure Key Vault secrets should have an expiration date

### DIFF
--- a/azure/vault/main.tf
+++ b/azure/vault/main.tf
@@ -20,9 +20,10 @@ resource "azurerm_key_vault" "example" {
 }
 
 resource "azurerm_key_vault_secret" "example" {
-  name         = "secret-sauce"
-  value        = "UyVc_EG&ZPn=3m6%"
-  key_vault_id = azurerm_key_vault.example.id
+  name            = "secret-sauce"
+  value           = "UyVc_EG&ZPn=3m6%"
+  key_vault_id    = azurerm_key_vault.example.id
+  expiration_date = "String<Expiration UTC datetime (Y-m-d'T'H:M:S'Z')>"
 }
 
 # then generate a key used to encrypt the disks


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-KV-005 

 **Violation Description:** 

 This policy identifies Azure Key Vault secrets that do not have an expiry date. As a best practice, set an expiration date for each secret and rotate the secret regularly.<br><br>Before you activate this policy, ensure that you have added the <compliance-software> Service Principal to each Key Vault: https://docs.paloaltonetworks.com/<compliance-software>/<compliance-software>-admin/connect-your-cloud-platform-to-<compliance-software>/onboard-your-azure-account/set-up-your-azure-account.html<br><br>Alternatively, run the following command on the Azure cloud shell:<br>az keyvault list | jq '.[].name' | xargs -I {} az keyvault set-policy --name {} --certificate-permissions list listissuers --key-permissions list --secret-permissions list --spn <<compliance-software>_app_id> 

 **How to Fix:** 

 In 'azurerm_key_vault_secret' resource, set valid date other then null in property 'expiration_date' to fix the issue. please visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret#expiration_date' target='_blank'>here</a> for details.