### PR TITLE
Fixed PR-AZR-TRF-SQL-056: Ensure ssl enforcement is enabled on MariaDB Server.

### DIFF
--- a/azure/mariadb_database/main.tf
+++ b/azure/mariadb_database/main.tf
@@ -14,10 +14,10 @@ resource "azurerm_mariadb_server" "example" {
   backup_retention_days        = 7
   geo_redundant_backup_enabled = false
 
-  administrator_login          = "acctestun"
-  administrator_login_password = "H@Sh1CoR3!"
-  version                      = "10.2"
-  ssl_enforcement_enabled      = false
+  administrator_login           = "acctestun"
+  administrator_login_password  = "H@Sh1CoR3!"
+  version                       = "10.2"
+  ssl_enforcement_enabled       = true
   public_network_access_enabled = true
 }
 


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-SQL-056 

 **Violation Description:** 

 Enable SSL connection on MariaDB Servers. Rationale: SSL connectivity helps to provide a new layer of security, by connecting database server to client applications using Secure Sockets Layer (SSL). Enforcing SSL connections between database server and client applications helps protect against 'man in the middle' attacks by encrypting the data stream between the server and application. 

 **How to Fix:** 

 In 'azurerm_mariadb_server' resource, set 'ssl_enforcement_enabled = true' to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mariadb_server#ssl_enforcement_enabled' target='_blank'>here</a> for details.