### PR TITLE
Fixed PR-AZR-TRF-SQL-057: Ensure MariaDB servers don't have public network access enabled

### DIFF
--- a/azure/mariadb_database/main.tf
+++ b/azure/mariadb_database/main.tf
@@ -14,11 +14,11 @@ resource "azurerm_mariadb_server" "example" {
   backup_retention_days        = 7
   geo_redundant_backup_enabled = false
 
-  administrator_login          = "acctestun"
-  administrator_login_password = "H@Sh1CoR3!"
-  version                      = "10.2"
-  ssl_enforcement_enabled      = false
-  public_network_access_enabled = true
+  administrator_login           = "acctestun"
+  administrator_login_password  = "H@Sh1CoR3!"
+  version                       = "10.2"
+  ssl_enforcement_enabled       = false
+  public_network_access_enabled = false
 }
 
 resource "azurerm_mariadb_database" "example" {


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-SQL-057 

 **Violation Description:** 

 Always use Private Endpoint for MariaDB Server 

 **How to Fix:** 

 In 'azurerm_mariadb_server' resource, set 'public_network_access_enabled = false' or make sure resource 'azurerm_private_endpoint' exist to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mariadb_server#public_network_access_enabled' target='_blank'>here</a> for details.