### PR TITLE
Fixed PR-AZR-TRF-SQL-058: Ensure Geo-redundant backup is enabled on MariaDB server.

### DIFF
--- a/azure/mariadb_database/main.tf
+++ b/azure/mariadb_database/main.tf
@@ -12,12 +12,12 @@ resource "azurerm_mariadb_server" "example" {
 
   storage_mb                   = 51200
   backup_retention_days        = 7
-  geo_redundant_backup_enabled = false
+  geo_redundant_backup_enabled = true
 
-  administrator_login          = "acctestun"
-  administrator_login_password = "H@Sh1CoR3!"
-  version                      = "10.2"
-  ssl_enforcement_enabled      = false
+  administrator_login           = "acctestun"
+  administrator_login_password  = "H@Sh1CoR3!"
+  version                       = "10.2"
+  ssl_enforcement_enabled       = false
   public_network_access_enabled = true
 }
 


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-SQL-058 

 **Violation Description:** 

 Azure Database for MariaDB provides the flexibility to choose between locally redundant or geo-redundant backup storage in the General Purpose and Memory Optimized tiers. When the backups are stored in geo-redundant backup storage, they are not only stored within the region in which your server is hosted, but are also replicated to a paired data center. This provides better protection and ability to restore your server in a different region in the event of a disaster. The Basic tier only offers locally redundant backup storage. 

 **How to Fix:** 

 In 'azurerm_mariadb_server' resource, set 'geo_redundant_backup_enabled = true' to fix the issue. Visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mariadb_server#geo_redundant_backup_enabled' target='_blank'>here</a> for details.