### PR TITLE
Fixed PR-AZR-TRF-NTW-002: Azure Network Watcher Network Security Group (NSG) traffic analytics should be enabled

### DIFF
--- a/azure/networkwatcher/terraform.tfvars
+++ b/azure/networkwatcher/terraform.tfvars
@@ -1,2 +1,2 @@
 location                 = "eastus2"
-traffic_analytics_enable = false
+traffic_analytics_enable = true


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-NTW-002 

 **Violation Description:** 

 This policy identifies Azure Network Security Groups (NSG) for which flow logs are disabled. To perform this check, enable this action on the Azure Service Principal: 'Microsoft.Network/networkWatchers/queryFlowLogStatus/action'.<br><br>NSG flow logs, a feature of the Network Watcher app, enable you to view information about ingress and egress IP traffic through an NSG. The flow logs include information such as:<br>- Outbound and inbound flows on a per-rule basis.<br>- Network interface to which the flow applies.<br>- 5-tuple information about the flow (source/destination IP, source/destination port, protocol).<br>- Whether the traffic was allowed or denied.<br><br>As a best practice, enable NSG flow logs to improve network visibility. 

 **How to Fix:** 

 In 'azurerm_network_watcher_flow_log' resource, set 'enabled = true' under 'traffic_analytics' block to fix the issue. please visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_watcher_flow_log#enabled' target='_blank'>here</a> for details.