### PR TITLE
Fixed PR-AZR-TRF-NTW-003: Azure Network Watcher Network Security Group (NSG) flow logs retention should be greater than 90 days

### DIFF
--- a/azure/networkwatcher/main.tf
+++ b/azure/networkwatcher/main.tf
@@ -1,6 +1,6 @@
 resource "azurerm_resource_group" "application1" {
-  name                        = "app1_rg"
-  location                    = "northcentralus"
+  name     = "app1_rg"
+  location = "northcentralus"
 }
 
 # Networking components to be monitored
@@ -23,13 +23,13 @@ resource "azurerm_network_security_group" "application1" {
 }
 
 resource "azurerm_storage_account" "network_log_data" {
-  name                      = "applogdata"
-  resource_group_name       = azurerm_resource_group.application1.name
-  location                  = var.location
+  name                = "applogdata"
+  resource_group_name = azurerm_resource_group.application1.name
+  location            = var.location
 
-  account_tier              = "Standard"
-  account_replication_type  = "GRS"
-  min_tls_version           = "TLS1_2"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  min_tls_version          = "TLS1_2"
 }
 
 resource "azurerm_log_analytics_workspace" "traffic_analytics" {
@@ -55,8 +55,8 @@ resource "azurerm_network_watcher_flow_log" "app1_network_logs" {
   enabled                   = false
 
   retention_policy {
-    enabled = false
-    days    = 90
+    enabled = true
+    days    = 120
   }
 
   traffic_analytics {


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-NTW-003 

 **Violation Description:** 

 This policy identifies Azure Network Security Groups (NSG) for which flow logs retention period is less than 90 days. To perform this check, enable this action on the Azure Service Principal: 'Microsoft.Network/networkWatchers/queryFlowLogStatus/action'.<br><br>NSG flow logs, a feature of the Network Watcher app, enable you to view information about ingress and egress IP traffic through an NSG. The flow logs include information such as:<br>- Outbound and inbound flows on a per-rule basis.<br>- Network interface to which the flow applies.<br>- 5-tuple information about the flow (source/destination IP, source/destination port, protocol).<br>- Whether the traffic was allowed or denied.<br><br>As a best practice, enable NSG flow logs and set the log retention period to at least 90 days. 

 **How to Fix:** 

 In 'azurerm_network_watcher_flow_log' resource, set 'enabled = true' and 'days = 90' under 'retention_policy' block to fix the issue. please visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_watcher_flow_log#enabled' target='_blank'>here</a> for details.