### PR TITLE
Fixed PR-AWS-TRF-KMS-002: AWS KMS Customer Managed Key not in use

### DIFF
--- a/aws/workspaces/main.tf
+++ b/aws/workspaces/main.tf
@@ -119,4 +119,5 @@ resource "aws_directory_service_directory" "example" {
 
 resource "aws_kms_key" "example" {
   description = "WorkSpaces example key"
+  is_enabled  = true
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-KMS-002 

 **Violation Description:** 

 This policy identifies KMS Customer Managed Keys(CMKs) which are not usable. When you create a CMK, it is enabled by default. If you disable a CMK or schedule it for deletion makes it unusable, it cannot be used to encrypt or decrypt data and AWS KMS does not rotate the backing keys until you re-enable it. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key' target='_blank'>here</a>