### PR TITLE
Fixed PR-AWS-TRF-CT-004: CloudTrail trail is not integrated with CloudWatch Log

### DIFF
--- a/aws/cloudtrail/terraform.tfvars
+++ b/aws/cloudtrail/terraform.tfvars
@@ -23,19 +23,19 @@ expire_noncurrent_versions                      = true
 lifecycle_days_to_expiration                    = 365
 server_side_encryption_configuration            = []
 
-name                            = "prancer-ct"
-s3_key_prefix                   = "prefix"
-enable_logging                  = true
-enable_log_file_validation      = false
-is_multi_region_trail           = false
-include_global_service_events   = true
-cloud_watch_logs_role_arn       = ""
-cloud_watch_logs_group_arn      = ""
-kms_key_arn                     = ""
-is_organization_trail           = false
-event_selector                  = []
+name                          = "prancer-ct"
+s3_key_prefix                 = "prefix"
+enable_logging                = true
+enable_log_file_validation    = false
+is_multi_region_trail         = false
+include_global_service_events = true
+cloud_watch_logs_role_arn     = "String<Role for the CloudWatch Logs endpoint to assume to write to a user’s log group>"
+cloud_watch_logs_group_arn    = ""
+kms_key_arn                   = ""
+is_organization_trail         = false
+event_selector                = []
 
 tags = {
   Environment = "Production"
-  Project = "Prancer"
+  Project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-CT-004 

 **Violation Description:** 

 Enabling the CloudTrail trail logs integrated with CloudWatch Logs will enable the real-time as well as historic activity logging. This will further effective monitoring and alarm capability. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail' target='_blank'>here</a>