### PR TITLE
PR-AWS-TRF-AG-001: API Gateway should have API Endpoint type as private and not exposed to internet

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -478,6 +478,9 @@ resource "aws_api_gateway_authorizer" "demo" {
 
 resource "aws_api_gateway_rest_api" "demo" {
   name = "auth-demo"
+  endpoint_configuration {
+    types = ["PRIVATE"]
+  }
 }
 
 resource "aws_iam_role" "invocation_role" {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-AG-001 

 **Violation Description:** 

 Ensure that the Api endpoint type in api gateway is set to private and Is not exposed to the public internet 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_rest_api' target='_blank'>here</a>