### PR TITLE
Fixed PR-AWS-TRF-AS-002: Ensure auto scaling groups associated with a load balancer use elastic load balancing health checks

### DIFF
--- a/aws/asg/main.tf
+++ b/aws/asg/main.tf
@@ -48,6 +48,7 @@ resource "aws_autoscaling_group" "web-asg" {
     value               = "web-asg"
     propagate_at_launch = "true"
   }
+  health_check_type = "ELB"
 }
 
 resource "aws_launch_configuration" "web-lc" {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-AS-002 

 **Violation Description:** 

 If you configure an Auto Scaling group to use load balancer (ELB) health checks, it considers the instance unhealthy if it fails either the EC2 status checks or the load balancer health checks 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group' target='_blank'>here</a>