### PR TITLE
Fixed PR-AWS-TRF-CFG-002: Ensure AWS config is enabled in all regions

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -654,6 +654,11 @@ resource "aws_config_configuration_aggregator" "organization" {
     all_regions = false
     role_arn    = aws_iam_role.organization.arn
   }
+  artifacts {
+    organization_aggregation_source {
+      all_regions = true
+    }
+  }
 }
 
 resource "aws_iam_role" "organization" {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-CFG-002 

 **Violation Description:** 

 AWS Config is a web service that performs the configuration management of supported AWS resources within your account and delivers log files to you. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_aggregator' target='_blank'>here</a> 