### PR TITLE
Fixed PR-AWS-CFR-MQ-002: Ensure Amazon MQ Broker logging is enabled

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -467,6 +467,9 @@ resource "aws_mq_broker" "example" {
     username = "ExampleUser"
     password = "MindTheGap"
   }
+  logs {
+    general = true
+  }
 }
 
 resource "aws_api_gateway_authorizer" "demo" {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-MQ-002 

 **Violation Description:** 

 Amazon MQ is integrated with CloudTrail and provides a record of the Amazon MQ calls made by a user, role, or AWS service. It supports logging both the request parameters and the responses for APIs as events in CloudTrail 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/mq_broker' target='_blank'>here</a>