### PR TITLE
Fixed PR-AWS-TRF-R53-001: Ensure Route53 DNS evaluateTargetHealth is enabled

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -568,7 +568,7 @@ resource "aws_route53_record" "www" {
   alias {
     name                   = aws_elb.main.dns_name
     zone_id                = aws_elb.main.zone_id
-    evaluate_target_health = false
+    evaluate_target_health = true
   }
 }
 


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-R53-001 

 **Violation Description:** 

 The EvaluateTargetHealth of Route53 is not enabled, an alias record can't inherits the health of the referenced AWS resource, such as an ELB load balancer or another record in the hosted zone. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record' target='_blank'>here</a>