### PR TITLE
Fixed PR-AWS-TRF-GLUE-001: Ensure Glue Data Catalog encryption is enabled

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -786,11 +786,11 @@ resource "aws_glue_data_catalog_encryption_settings" "example" {
   data_catalog_encryption_settings {
     connection_password_encryption {
       aws_kms_key_id                       = aws_kms_key.test.arn
-      return_connection_password_encrypted = false
+      return_connection_password_encrypted = true
     }
 
     encryption_at_rest {
-      catalog_encryption_mode = ""
+      catalog_encryption_mode = "SSE-KMS"
       sse_aws_kms_key_id      = aws_kms_key.test.arn
     }
   }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-GLUE-001 

 **Violation Description:** 

 Ensure that encryption at rest is enabled for your Amazon Glue Data Catalogs in order to meet regulatory requirements and prevent unauthorized users from getting access to sensitive data 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_data_catalog_encryption_settings' target='_blank'>here</a>