### PR TITLE
Fixed PR-AWS-TRF-GLUE-002: Ensure AWS Glue security configuration encryption is enabled

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -801,16 +801,16 @@ resource "aws_glue_security_configuration" "example" {
 
   encryption_configuration {
     cloudwatch_encryption {
-      cloudwatch_encryption_mode = "DISABLED"
+      cloudwatch_encryption_mode = "SSE-KMS"
     }
 
     job_bookmarks_encryption {
-      job_bookmarks_encryption_mode = "DISABLED"
+      job_bookmarks_encryption_mode = "SSE-KMS"
     }
 
     s3_encryption {
       kms_key_arn        = data.aws_kms_key.example.arn
-      s3_encryption_mode = "DISABLED"
+      s3_encryption_mode = "SSE-KMS"
     }
   }
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-GLUE-002 

 **Violation Description:** 

 Ensure AWS Glue security configuration encryption is enabled 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_security_configuration' target='_blank'>here</a>