### PR TITLE
Fixed PR-AWS-TRF-AS-001: Ensure EBS volumes have encrypted launch configurations

### DIFF
--- a/aws/asg/main.tf
+++ b/aws/asg/main.tf
@@ -59,6 +59,9 @@ resource "aws_launch_configuration" "web-lc" {
   security_groups = [aws_security_group.default.id]
   user_data       = file("userdata.sh")
   key_name        = var.key_name
+  ebs_block_device {
+    encrypted = true
+  }
 }
 
 # Our default security group to access


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-AS-001 

 **Violation Description:** 

 Amazon Elastic Block Store (EBS) volumes allow you to create encrypted launch configurations when creating EC2 instances and auto scaling. When the entire EBS volume is encrypted, data stored at rest on the volume, disk I/O, snapshots created from the volume, and data in-transit between EBS and EC2 are all encrypted. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration' target='_blank'>here</a>