### PR TITLE
Fixed PR-AWS-TRF-WAF-001: JMSAppender in Log4j 1.2 is vulnerable to deserialization of untrusted data when the attacker has write access to the Log4j configuration

### DIFF
--- a/aws/waf/main.tf
+++ b/aws/waf/main.tf
@@ -11,18 +11,12 @@ resource "aws_wafv2_web_acl" "example" {
     name     = "rule-1"
     priority = 1
 
-    override_action {
-      count {}
-    }
 
     statement {
       managed_rule_group_statement {
         name        = "AWSManagedRulesKnownBadInputsRuleSet"
         vendor_name = "AWS"
 
-        excluded_rule {
-          name = "Log4jRCE"
-        }
 
         excluded_rule {
           name = "NoUserAgent_HEADER"
@@ -41,6 +35,7 @@ resource "aws_wafv2_web_acl" "example" {
       metric_name                = "friendly-rule-metric-name"
       sampled_requests_enabled   = false
     }
+    remove_blocks = []
   }
 
   tags = {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-WAF-001 

 **Violation Description:** 

 Apache Log4j2 2.0-beta9 through 2.12.1 and 2.13.0 through 2.15.0 JNDI features used in configuration, log messages, and parameters do not protect against attacker controlled LDAP and other JNDI related endpoints 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl' target='_blank'>here</a>