### PR TITLE
Fixed PR-AWS-TRF-VPC-001: AWS VPC subnets should not allow automatic public IP assignment

### DIFF
--- a/aws/vpc/terraform.tfvars
+++ b/aws/vpc/terraform.tfvars
@@ -1,19 +1,19 @@
-cidr_block                      = "10.10.0.0/16"
-instance_tenancy                = "default"
-enable_dns_hostnames            = false
-enable_dns_support              = true
-enable_classiclink              = null
-enable_classiclink_dns_support  = null
-enable_ipv6                     = false
+cidr_block                     = "10.10.0.0/16"
+instance_tenancy               = "default"
+enable_dns_hostnames           = false
+enable_dns_support             = true
+enable_classiclink             = null
+enable_classiclink_dns_support = null
+enable_ipv6                    = false
 
 subnet_cidr_block               = "10.10.1.0/24"
 availability_zone               = null
 availability_zone_id            = null
-map_public_ip_on_launch         = true
+map_public_ip_on_launch         = false
 assign_ipv6_address_on_creation = false
 ipv6_cidr_block                 = null
 
-tags                            = {
+tags = {
   environment = "Production"
-  project = "Prancer"
+  project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-VPC-001 

 **Violation Description:** 

 This policy identifies VPC subnets which allow automatic public IP assignment. VPC subnet is a part of the VPC having its own rules for traffic. Assigning the Public IP to the subnet automatically (on launch) can accidentally expose the instances within this subnet to internet and should be edited to 'No' post creation of the Subnet. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet' target='_blank'>here</a>