### PR TITLE
Fixed PR-AWS-TRF-VPC-001: AWS VPC subnets should not allow automatic public IP assignment

### DIFF
--- a/aws/sg/extrasg.tf
+++ b/aws/sg/extrasg.tf
@@ -30,7 +30,7 @@ resource "aws_subnet" "tf_test_subnet" {
 
   cidr_block = "10.0.0.0/24"
 
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = false
 
 
 


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-VPC-001 

 **Violation Description:** 

 This policy identifies VPC subnets which allow automatic public IP assignment. VPC subnet is a part of the VPC having its own rules for traffic. Assigning the Public IP to the subnet automatically (on launch) can accidentally expose the instances within this subnet to internet and should be edited to 'No' post creation of the Subnet. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet' target='_blank'>here</a>