### PR TITLE
Fixed PR-AWS-TRF-VPC-003: Ensure VPC endpoint service is configured for manual acceptance

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -865,7 +865,7 @@ resource "aws_subnet" "tf_test_subnet" {
   vpc_id                  = aws_vpc.default.id
   cidr_block              = "10.0.0.0/24"
   map_public_ip_on_launch = true
-  acceptance_required     = false
+  acceptance_required     = true
 
   depends_on = [aws_internet_gateway.gw]
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-VPC-003 

 **Violation Description:** 

 acceptance_required Indicates whether requests from service consumers to create an endpoint to your service must be accepted, we recommend you to enable this feature 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_service' target='_blank'>here</a>