### PR TITLE
PR-AWS-TRF-EKS-002: AWS EKS unsupported Master node version.

### DIFF
--- a/aws/modules/eks/main.tf
+++ b/aws/modules/eks/main.tf
@@ -2,7 +2,6 @@ resource "aws_eks_cluster" "eks" {
   name                      = var.name
   tags                      = var.tags
   role_arn                  = var.role_arn
-  version                   = var.kubernetes_version
   enabled_cluster_log_types = var.enabled_cluster_log_types
 
   dynamic "encryption_config" {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-EKS-002 

 **Violation Description:** 

 Ensure your EKS Master node version is supported. This policy checks your EKS master node version and generates an alert if the version running is unsupported. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster' target='_blank'>here</a>