### PR TITLE
Fixed PR-AWS-TRF-ES-003: AWS Elasticsearch domain has Dedicated master set to disabled

### DIFF
--- a/aws/elasticsearch/terraform.tfvars
+++ b/aws/elasticsearch/terraform.tfvars
@@ -15,14 +15,14 @@ domain_endpoint_options_enforce_https                    = false
 domain_endpoint_options_tls_security_policy              = "Policy-Min-TLS-1-0-2019-07"
 instance_count                                           = 4
 instance_type                                            = "t2.small.elasticsearch"
-dedicated_master_enabled                                 = false
+dedicated_master_enabled                                 = true
 dedicated_master_count                                   = 3
 dedicated_master_type                                    = "t2.small.elasticsearch"
 zone_awareness_enabled                                   = false
 warm_enabled                                             = false
 warm_count                                               = 2
 warm_type                                                = "ultrawarm1.medium.elasticsearch"
-zone_awareness_config                                    = [{availability_zone_count = 2}]
+zone_awareness_config                                    = [{ availability_zone_count = 2 }]
 node_to_node_encryption_enabled                          = false
 vpc_enabled                                              = false
 subnet_ids                                               = []
@@ -38,7 +38,7 @@ log_publishing_search_cloudwatch_log_group_arn           = ""
 log_publishing_application_enabled                       = false
 log_publishing_application_cloudwatch_log_group_arn      = ""
 
-tags                                = {
+tags = {
   environment = "Production"
-  project = "Prancer"
+  project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-ES-003 

 **Violation Description:** 

 This policy identifies Elasticsearch domains for which Dedicated master is disabled in your AWS account. If dedicated master nodes are provided those handle the management tasks and cluster nodes can easily manage index and search requests from different types of workload and make them more resilient in production. Dedicated master nodes improve environmental stability by freeing all the management tasks from the cluster data nodes. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain' target='_blank'>here</a>