### PR TITLE
Fixed PR-AWS-TRF-ES-004: AWS Elasticsearch domain has Index slow logs set to disabled

### DIFF
--- a/aws/elasticsearch/terraform.tfvars
+++ b/aws/elasticsearch/terraform.tfvars
@@ -22,7 +22,7 @@ zone_awareness_enabled                                   = false
 warm_enabled                                             = false
 warm_count                                               = 2
 warm_type                                                = "ultrawarm1.medium.elasticsearch"
-zone_awareness_config                                    = [{availability_zone_count = 2}]
+zone_awareness_config                                    = [{ availability_zone_count = 2 }]
 node_to_node_encryption_enabled                          = false
 vpc_enabled                                              = false
 subnet_ids                                               = []
@@ -31,14 +31,14 @@ cognito_authentication_enabled                           = false
 cognito_user_pool_id                                     = ""
 cognito_identity_pool_id                                 = ""
 cognito_iam_role_arn                                     = ""
-log_publishing_index_enabled                             = false
+log_publishing_index_enabled                             = true
 log_publishing_index_cloudwatch_log_group_arn            = ""
 log_publishing_search_enabled                            = false
 log_publishing_search_cloudwatch_log_group_arn           = ""
 log_publishing_application_enabled                       = false
 log_publishing_application_cloudwatch_log_group_arn      = ""
 
-tags                                = {
+tags = {
   environment = "Production"
-  project = "Prancer"
+  project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-ES-004 

 **Violation Description:** 

 This policy identifies Elasticsearch domains for which Index slow logs is disabled in your AWS account. Enabling support for publishing indexing slow logs to AWS CloudWatch Logs enables you have full insight into the performance of indexing operations performed on your Elasticsearch clusters. This will help you in identifying performance issues caused by specific queries or due to changes in cluster usage, so that you can optimize your index configuration to address the problem. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain' target='_blank'>here</a>