### PR TITLE
Fixed PR-AWS-TRF-ES-006: AWS Elasticsearch domain has Zone Awareness set to disabled

### DIFF
--- a/aws/elasticsearch/terraform.tfvars
+++ b/aws/elasticsearch/terraform.tfvars
@@ -18,11 +18,11 @@ instance_type                                            = "t2.small.elasticsear
 dedicated_master_enabled                                 = false
 dedicated_master_count                                   = 3
 dedicated_master_type                                    = "t2.small.elasticsearch"
-zone_awareness_enabled                                   = false
+zone_awareness_enabled                                   = true
 warm_enabled                                             = false
 warm_count                                               = 2
 warm_type                                                = "ultrawarm1.medium.elasticsearch"
-zone_awareness_config                                    = [{availability_zone_count = 2}]
+zone_awareness_config                                    = [{ availability_zone_count = 2 }]
 node_to_node_encryption_enabled                          = false
 vpc_enabled                                              = false
 subnet_ids                                               = []
@@ -38,7 +38,7 @@ log_publishing_search_cloudwatch_log_group_arn           = ""
 log_publishing_application_enabled                       = false
 log_publishing_application_cloudwatch_log_group_arn      = ""
 
-tags                                = {
+tags = {
   environment = "Production"
-  project = "Prancer"
+  project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-ES-006 

 **Violation Description:** 

 This policy identifies Elasticsearch domains for which Zone Awareness is disabled in your AWS account. Enabling Zone Awareness (cross-zone replication) increases the availability by distributing your Elasticsearch data nodes across two availability zones available in the same AWS region. It also prevents data loss and minimizes downtime in the event of node or availability zone failure. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain' target='_blank'>here</a>