### PR TITLE
Fixed PR-AWS-TRF-ES-007: Ensure node-to-node encryption is enabled on each ElasticSearch Domain

### DIFF
--- a/aws/elasticsearch/terraform.tfvars
+++ b/aws/elasticsearch/terraform.tfvars
@@ -22,8 +22,8 @@ zone_awareness_enabled                                   = false
 warm_enabled                                             = false
 warm_count                                               = 2
 warm_type                                                = "ultrawarm1.medium.elasticsearch"
-zone_awareness_config                                    = [{availability_zone_count = 2}]
-node_to_node_encryption_enabled                          = false
+zone_awareness_config                                    = [{ availability_zone_count = 2 }]
+node_to_node_encryption_enabled                          = true
 vpc_enabled                                              = false
 subnet_ids                                               = []
 automated_snapshot_start_hour                            = 0
@@ -38,7 +38,7 @@ log_publishing_search_cloudwatch_log_group_arn           = ""
 log_publishing_application_enabled                       = false
 log_publishing_application_cloudwatch_log_group_arn      = ""
 
-tags                                = {
+tags = {
   environment = "Production"
-  project = "Prancer"
+  project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-ES-007 

 **Violation Description:** 

 Ensure that node-to-node encryption feature is enabled for your AWS ElasticSearch domains (clusters) in order to add an extra layer of data protection on top of the existing ES security features such as HTTPS client to cluster encryption and data-at-rest encryption, and meet strict compliance requirements. The ElasticSearch node-to-node encryption capability provides the additional layer of security by implementing Transport Layer Security (TLS) for all communications between the nodes provisioned within the cluster. The feature ensures that any data sent to your AWS ElasticSearch domain over HTTPS remains encrypted in transit while it is being distributed and replicated between the nodes. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain' target='_blank'>here</a>