### PR TITLE
Fixed PR-AWS-TRF-ES-008: AWS Elasticsearch domain is not configured with HTTPS

### DIFF
--- a/aws/elasticsearch/terraform.tfvars
+++ b/aws/elasticsearch/terraform.tfvars
@@ -11,7 +11,7 @@ ebs_volume_type                                          = "gp2"
 ebs_iops                                                 = 0
 encrypt_at_rest_enabled                                  = false
 encrypt_at_rest_kms_key_id                               = ""
-domain_endpoint_options_enforce_https                    = false
+domain_endpoint_options_enforce_https                    = true
 domain_endpoint_options_tls_security_policy              = "Policy-Min-TLS-1-0-2019-07"
 instance_count                                           = 4
 instance_type                                            = "t2.small.elasticsearch"
@@ -22,7 +22,7 @@ zone_awareness_enabled                                   = false
 warm_enabled                                             = false
 warm_count                                               = 2
 warm_type                                                = "ultrawarm1.medium.elasticsearch"
-zone_awareness_config                                    = [{availability_zone_count = 2}]
+zone_awareness_config                                    = [{ availability_zone_count = 2 }]
 node_to_node_encryption_enabled                          = false
 vpc_enabled                                              = false
 subnet_ids                                               = []
@@ -38,7 +38,7 @@ log_publishing_search_cloudwatch_log_group_arn           = ""
 log_publishing_application_enabled                       = false
 log_publishing_application_cloudwatch_log_group_arn      = ""
 
-tags                                = {
+tags = {
   environment = "Production"
-  project = "Prancer"
+  project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-ES-008 

 **Violation Description:** 

 This policy identifies Elasticsearch domains that are not configured with HTTPS. Amazon Elasticsearch domains allow all traffic to be submitted over HTTPS, ensuring all communications between application and domain are encrypted. It is recommended to enable HTTPS so that all communication between the application and all data access goes across an encrypted communication channel to eliminate man-in-the-middle attacks 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain' target='_blank'>here</a>