### PR TITLE
Fixed PR-AWS-TRF-NACL-004: AWS Network ACLs with Outbound rule to allow All ICMP IPv4

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -269,7 +269,7 @@ resource "aws_network_acl_rule" "egress1" {
   rule_number    = 200
   egress         = true
   protocol       = -1
-  rule_action    = "allow"
+  rule_action    = "deny"
   cidr_block     = "0.0.0.0/0"
   from_port      = 22
   to_port        = 22


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-NACL-004 

 **Violation Description:** 

 This policy identifies ACLs which allows traffic on all protocol. A network access control list (ACL) is an optional layer of security for your VPC that acts as a firewall for controlling traffic in and out of one or more subnets. By default, ACL allows all inbound and outbound IPv4 traffic and, if applicable, IPv6 traffic. Outbound rules that allow unrestricted traffic to the internet can be a security risk. As a best practice, it is recommended to configure ACL to restrict traffic on authorized protocols. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule' target='_blank'>here</a>