### PR TITLE
Fixed PR-AWS-TRF-NACL-006: AWS Network ACLs with Outbound rule to allow All Traffic

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -247,7 +247,7 @@ resource "aws_network_acl_rule" "ingress1" {
   rule_number    = 200
   egress         = false
   protocol       = -1
-  rule_action    = "allow"
+  rule_action    = "deny"
   cidr_block     = "0.0.0.0/0"
   from_port      = 22
   to_port        = 22


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-NACL-006 

 **Violation Description:** 

 This policy identifies ACLs which allows traffic on all protocols. A network access control list (ACL) is an optional layer of security for your VPC that acts as a firewall for controlling traffic in and out of one or more subnets. By default, ACL allows all inbound and outbound IPv4 traffic and, if applicable, IPv6 traffic. Outbound rules that allow unrestricted traffic to the internet can be a security risk. As a best practice, it is recommended to configure ACLs to restrict traffic on authorized protocols. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule' target='_blank'>here</a>