### PR TITLE
Fixed PR-AWS-TRF-NACL-007: Unrestricted Inbound Traffic on Remote Server Administration Ports

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -247,7 +247,7 @@ resource "aws_network_acl_rule" "ingress1" {
   rule_number    = 200
   egress         = false
   protocol       = -1
-  rule_action    = "allow"
+  rule_action    = "deny"
   cidr_block     = "0.0.0.0/0"
   from_port      = 22
   to_port        = 22
@@ -258,7 +258,7 @@ resource "aws_network_acl_rule" "ingress2" {
   rule_number     = 200
   egress          = false
   protocol        = -1
-  rule_action     = "allow"
+  rule_action     = "deny"
   ipv6_cidr_block = "::/0"
   from_port       = 22
   to_port         = 22


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-NACL-007 

 **Violation Description:** 

 Check your Amazon VPC Network Access Control Lists (NACLs) for inbound/ingress rules that allow unrestricted traffic (i.e. 0.0.0.0/0) on TCP ports 22 (SSH) and 3389 (RDP) and limit access to trusted IP addresses or IP ranges only in order to implement the Principle of Least Privilege (POLP) and reduce the attack surface at the subnet level. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule' target='_blank'>here</a>