### PR TITLE
Fixed PR-AWS-TRF-SGM-002: AWS SageMaker notebook instance with root access enabled

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -576,7 +576,7 @@ resource "aws_sagemaker_notebook_instance" "ni" {
   name                   = "my-notebook-instance"
   role_arn               = aws_iam_role.role.arn
   instance_type          = "ml.t2.medium"
-  root_access            = "Enabled"
+  root_access            = "Disabled"
   direct_internet_access = "Enabled"
 
   subnet_id = []


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-SGM-002 

 **Violation Description:** 

 This policy identifies the SageMaker notebook instances which are enabled with root access. Root access means having administrator privileges, users with root access can access and edit all files on the compute instance, including system-critical files. Removing root access prevents notebook users from deleting system-level software, installing new software, and modifying essential environment components.
NOTE: Lifecycle configurations need root access to be able to set up a notebook instance. Because of this, lifecycle configurations associated with a notebook instance always run with root access even if you disable root access for users.

For more details:
https://docs.aws.amazon.com/sagemaker/latest/dg/nbi-root-access.html 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sagemaker_notebook_instance' target='_blank'>here</a>