### PR TITLE
Fixed PR-AWS-TRF-SGM-003: AWS SageMaker notebook instance configured with direct internet access feature

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -577,7 +577,7 @@ resource "aws_sagemaker_notebook_instance" "ni" {
   role_arn               = aws_iam_role.role.arn
   instance_type          = "ml.t2.medium"
   root_access            = "Enabled"
-  direct_internet_access = "Enabled"
+  direct_internet_access = "Disabled"
 
   subnet_id = []
 


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-SGM-003 

 **Violation Description:** 

 This policy identifies SageMaker notebook instances that are configured with direct internet access feature. If AWS SageMaker notebook instances are configured with direct internet access feature, any machine outside the VPC can establish a connection to these instances, which provides an additional avenue for unauthorized access to data and the opportunity for malicious activity.

For more details:
https://docs.aws.amazon.com/sagemaker/latest/dg/appendix-notebook-and-internet-access.html 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sagemaker_notebook_instance' target='_blank'>here</a>