### PR TITLE
Fixed PR-AWS-TRF-CB-001: Ensure CodeBuild project Artifact encryption is not disabled

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -613,7 +613,7 @@ resource "aws_codebuild_project" "project-with-cache" {
 
   artifacts {
     type                = "NO_ARTIFACTS"
-    encryption_disabled = true
+    encryption_disabled = false
   }
 
   cache {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-CB-001 

 **Violation Description:** 

 AWS CodeBuild is a fully managed build service in the cloud. CodeBuild compiles your source code, runs unit tests, and produces artifacts that are ready to deploy. Build artifacts, such as a cache, logs, exported raw test report data files, and build results, are encrypted by default using CMKs for Amazon S3 that are managed by the AWS Key Management Service. If you do not want to use these CMKs, you must create and configure a customer-managed CMK. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_project' target='_blank'>here</a>