### PR TITLE
Fixed PR-AWS-TRF-ELB-004: AWS Elastic Load Balancer (Classic) with connection draining disabled

### DIFF
--- a/aws/elb/terraform.tfvars
+++ b/aws/elb/terraform.tfvars
@@ -1,10 +1,10 @@
-cidr_block                      = "10.10.0.0/16"
-instance_tenancy                = "default"
-enable_dns_hostnames            = false
-enable_dns_support              = true
-enable_classiclink              = null
-enable_classiclink_dns_support  = null
-enable_ipv6                     = false
+cidr_block                     = "10.10.0.0/16"
+instance_tenancy               = "default"
+enable_dns_hostnames           = false
+enable_dns_support             = true
+enable_classiclink             = null
+enable_classiclink_dns_support = null
+enable_ipv6                    = false
 
 subnet_cidr_block               = ["10.10.1.0/24", "10.10.3.0/24"]
 az                              = ["a", "b"]
@@ -26,14 +26,14 @@ ip_address_type                  = "ipv4"
 drop_invalid_header_fields       = false
 subnet_mapping                   = []
 
-elb_name                    = "prancer-elb"
-availability_zones          = ["us-east-2a", "us-east-2b"]
-security_groups             = []
-logging_enabled             = false
-bucket                      = ""
-bucket_prefix               = ""
-log_interval                    = 60
-listener                    = {
+elb_name           = "prancer-elb"
+availability_zones = ["us-east-2a", "us-east-2b"]
+security_groups    = []
+logging_enabled    = false
+bucket             = ""
+bucket_prefix      = ""
+log_interval       = 60
+listener = {
   listener1 = {
     instance_port      = 8000
     instance_protocol  = "http"
@@ -50,17 +50,17 @@ check_interval              = 30
 instances                   = []
 cross_zone_load_balancing   = false
 idle_timeout                = 400
-connection_draining         = false
+connection_draining         = true
 connection_draining_timeout = 400
 
-policy_name                      = "prancer-cipher"
-policy_type                      = "SSLNegotiationPolicyType"
-policy_attribute_map             = {
-  RC4-MD5 = "true"
+policy_name = "prancer-cipher"
+policy_type = "SSLNegotiationPolicyType"
+policy_attribute_map = {
+  RC4-MD5        = "true"
   Protocol-SSLv3 = "true"
 }
 
-tags                                = {
+tags = {
   environment = "Production"
-  project = "Prancer"
+  project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-ELB-004 

 **Violation Description:** 

 This policy identifies Classic Elastic Load Balancers which have connection draining disabled. Connection Draining feature ensures that a Classic load balancer stops sending requests to instances that are de-registering or unhealthy, while keeping the existing connections open. This enables the load balancer to complete in-flight requests made to instances that are de-registering or unhealthy. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elb' target='_blank'>here</a>