### PR TITLE
Fixed PR-AWS-TRF-ELB-004: AWS Elastic Load Balancer (Classic) with connection draining disabled

### DIFF
--- a/aws/asg/main.tf
+++ b/aws/asg/main.tf
@@ -30,6 +30,7 @@ resource "aws_elb" "web-elb" {
     target              = "HTTP:80/"
     interval            = 30
   }
+  connection_draining = true
 }
 
 resource "aws_autoscaling_group" "web-asg" {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-ELB-004 

 **Violation Description:** 

 This policy identifies Classic Elastic Load Balancers which have connection draining disabled. Connection Draining feature ensures that a Classic load balancer stops sending requests to instances that are de-registering or unhealthy, while keeping the existing connections open. This enables the load balancer to complete in-flight requests made to instances that are de-registering or unhealthy. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elb' target='_blank'>here</a>