### PR TITLE
Fixed PR-AWS-TRF-ELB-004: AWS Elastic Load Balancer (Classic) with connection draining disabled

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -558,6 +558,7 @@ resource "aws_elb" "main" {
     lb_port           = 80
     lb_protocol       = "http"
   }
+  connection_draining = true
 }
 
 resource "aws_route53_record" "www" {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-ELB-004 

 **Violation Description:** 

 This policy identifies Classic Elastic Load Balancers which have connection draining disabled. Connection Draining feature ensures that a Classic load balancer stops sending requests to instances that are de-registering or unhealthy, while keeping the existing connections open. This enables the load balancer to complete in-flight requests made to instances that are de-registering or unhealthy. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elb' target='_blank'>here</a>