### PR TITLE
Fixed PR-AWS-TRF-ELB-013: Ensure that Application Load Balancer drops HTTP headers

### DIFF
--- a/aws/modules/elbPolicy/main.tf
+++ b/aws/modules/elbPolicy/main.tf
@@ -9,6 +9,6 @@ resource "aws_load_balancer_policy" "wu-tang-ssl-tls-1-1" {
   }
   policy_attribute {
     name  = "routing.http.drop_invalid_header_fields.enabled"
-    value = "false"
+    value = "true"
   }
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-ELB-013 

 **Violation Description:** 

 Checks if rule evaluates AWS Application Load Balancers (ALB) to ensure they are configured to drop http headers. The rule is NON_COMPLIANT if the value of routing.http.drop_invalid_header_fields.enabled is set to false 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/load_balancer_listener_policy' target='_blank'>here</a>