### PR TITLE
Fixed PR-AWS-TRF-ELB-017: Ensure LoadBalancer scheme is set to internal and not internet-facing

### DIFF
--- a/aws/modules/elb/main.tf
+++ b/aws/modules/elb/main.tf
@@ -57,7 +57,7 @@ data "aws_acm_certificate" "example" {
 
 resource "aws_lb" "test" {
   name               = "test-lb-tf"
-  internal           = true
+  internal           = false
   load_balancer_type = "network"
   security_groups    = []
   target_type        = "instance"


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-ELB-017 

 **Violation Description:** 

 LoadBalancer scheme must be explicitly set to internal, else an Actor can allow access to ADATUM information through the misconfiguration of an ELB resource 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb' target='_blank'>here</a>