### PR TITLE
Fixed PR-AWS-TRF-EBS-001: AWS EBS volumes are not encrypted

### DIFF
--- a/aws/ec2/terraform.tfvars
+++ b/aws/ec2/terraform.tfvars
@@ -22,12 +22,12 @@ instance_initiated_shutdown_behavior = "stop"
 placement_group                      = null
 tenancy                              = null
 
-availability_zone                    = "us-east-2a"
-encrypted                            = false
-size                                 = 5
+availability_zone = "us-east-2a"
+encrypted         = true
+size              = 5
 
 tags = {
-  Name = "prancer-ec2"
+  Name        = "prancer-ec2"
   Environment = "Production"
-  Project = "Prancer"
+  Project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-EBS-001 

 **Violation Description:** 

 This policy identifies the EBS volumes which are not encrypted. The snapshots that you take of an encrypted EBS volume are also encrypted and can be moved between AWS Regions as needed. You cannot share encrypted snapshots with other AWS accounts and you cannot make them public. It is recommended that EBS volume should be encrypted. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_volume' target='_blank'>here</a>