### PR TITLE
Fixed PR-AWS-TRF-EFS-002: AWS Elastic File System (EFS) with encryption for data at rest disabled

### DIFF
--- a/aws/efs/terraform.tfvars
+++ b/aws/efs/terraform.tfvars
@@ -1,11 +1,11 @@
-encrypted                           = false
-kms_key_id                          = null
-performance_mode                    = "generalPurpose"
-provisioned_throughput_in_mibps     = 0
-throughput_mode                     = "bursting"
-transition_to_ia                    = ""
+encrypted                       = true
+kms_key_id                      = null
+performance_mode                = "generalPurpose"
+provisioned_throughput_in_mibps = 0
+throughput_mode                 = "bursting"
+transition_to_ia                = ""
 
-tags                                = {
+tags = {
   environment = "Production"
-  project = "Prancer"
+  project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-EFS-002 

 **Violation Description:** 

 This policy identifies Elastic File Systems (EFSs) for which encryption for data at rest disabled. It is highly recommended to implement at-rest encryption in order to prevent unauthorized users from reading sensitive data saved to EFS. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system' target='_blank'>here</a>