### PR TITLE
Fixed PR-AWS-TRF-S3-007: AWS S3 Object Versioning is disabled

### DIFF
--- a/aws/modules/s3/vars.tf
+++ b/aws/modules/s3/vars.tf
@@ -14,7 +14,7 @@ variable "acceleration_status" {
 
 variable "versioning_enabled" {
   description = "If versioning is set for buckets in case of accidental deletion"
-  default     = false
+  default     = true
 }
 
 variable "cors_allowed_headers" {

--- a/aws/s3/terraform.tfvars
+++ b/aws/s3/terraform.tfvars
@@ -1,7 +1,7 @@
 bucket_name                                     = "prancer-s3-bucket"
 bucket_acl                                      = "private"
 acceleration_status                             = "Suspended"
-versioning_enabled                              = false
+versioning_enabled                              = true
 cors_allowed_headers                            = ["Authorization"]
 cors_allowed_methods                            = ["GET"]
 cors_allowed_origins                            = ["*"]
@@ -42,7 +42,7 @@ s3_policy                                       = <<POLICY
   ]
 }
 POLICY
-s3_policy_sslonly = <<POLICY
+s3_policy_sslonly                               = <<POLICY
 {
   "Id": "sslonly",
   "Version": "2012-10-17",
@@ -65,7 +65,7 @@ s3_policy_sslonly = <<POLICY
 }
 POLICY
 
-tags                                     = {
+tags = {
   environment = "Production"
-  project = "Prancer"
+  project     = "Prancer"
 }

--- a/aws/s3/vars.tf
+++ b/aws/s3/vars.tf
@@ -1,7 +1,8 @@
 variable "bucket_name" {}
 variable "bucket_acl" {}
 variable "acceleration_status" {}
-variable "versioning_enabled" {}
+variable "versioning_enabled" { default = true
+}
 variable "cors_allowed_headers" {}
 variable "cors_allowed_methods" {}
 variable "cors_allowed_origins" {}


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-S3-007 

 **Violation Description:** 

 This policy identifies the S3 buckets which have Object Versioning disabled. S3 Object Versioning is an important capability in protecting your data within a bucket. Once you enable Object Versioning, you cannot remove it; you can suspend Object Versioning at any time on a bucket if you do not wish for it to persist. It is recommended to enable Object Versioning on S3. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket' target='_blank'>here</a>