### PR TITLE
Fixed PR-AWS-TRF-S3-007: AWS S3 Object Versioning is disabled

### DIFF
--- a/aws/cloudfront/main.tf
+++ b/aws/cloudfront/main.tf
@@ -1,20 +1,20 @@
 resource "aws_s3_bucket" "s3bucket" {
-    bucket = var.bucket
-    acl = "public-read"
+  bucket = var.bucket
+  acl    = "public-read"
 
-    website {
-        redirect_all_requests_to = "index.html"
-    }
+  website {
+    redirect_all_requests_to = "index.html"
+  }
 
-    cors_rule {
-        allowed_headers = ["*"]
-        allowed_methods = ["*"]
-        allowed_origins = ["*"]
-        expose_headers = ["ETag"]
-        max_age_seconds = 3000
-    }
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["*"]
+    allowed_origins = ["*"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
 
-    policy = <<EOF
+  policy = <<EOF
 {
     "Version": "2008-10-17",
     "Statement": [
@@ -30,10 +30,13 @@ resource "aws_s3_bucket" "s3bucket" {
     ]
 }
 EOF
+  versioning {
+    enabled = true
+  }
 }
 
 module "cloudfront" {
-  source  = "../modules/cloudfront"
+  source                            = "../modules/cloudfront"
   enabled                           = var.enabled
   is_ipv6_enabled                   = var.is_ipv6_enabled
   comment                           = var.comment


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-S3-007 

 **Violation Description:** 

 This policy identifies the S3 buckets which have Object Versioning disabled. S3 Object Versioning is an important capability in protecting your data within a bucket. Once you enable Object Versioning, you cannot remove it; you can suspend Object Versioning at any time on a bucket if you do not wish for it to persist. It is recommended to enable Object Versioning on S3. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket' target='_blank'>here</a>