### PR TITLE
Fixed PR-AWS-TRF-S3-007: AWS S3 Object Versioning is disabled

### DIFF
--- a/aws/msk/main.tf
+++ b/aws/msk/main.tf
@@ -39,6 +39,9 @@ resource "aws_cloudwatch_log_group" "test" {
 resource "aws_s3_bucket" "bucket" {
   bucket = "msk-broker-logs-bucket"
   acl    = "private"
+  versioning {
+    enabled = true
+  }
 }
 
 resource "aws_iam_role" "firehose_role" {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-S3-007 

 **Violation Description:** 

 This policy identifies the S3 buckets which have Object Versioning disabled. S3 Object Versioning is an important capability in protecting your data within a bucket. Once you enable Object Versioning, you cannot remove it; you can suspend Object Versioning at any time on a bucket if you do not wish for it to persist. It is recommended to enable Object Versioning on S3. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket' target='_blank'>here</a>