### PR TITLE
PR-AWS-TRF-S3-013: S3 buckets with configurations set to host websites

### DIFF
--- a/aws/cloudfront/main.tf
+++ b/aws/cloudfront/main.tf
@@ -1,20 +1,17 @@
 resource "aws_s3_bucket" "s3bucket" {
-    bucket = var.bucket
-    acl = "public-read"
+  bucket = var.bucket
+  acl    = "public-read"
 
-    website {
-        redirect_all_requests_to = "index.html"
-    }
 
-    cors_rule {
-        allowed_headers = ["*"]
-        allowed_methods = ["*"]
-        allowed_origins = ["*"]
-        expose_headers = ["ETag"]
-        max_age_seconds = 3000
-    }
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["*"]
+    allowed_origins = ["*"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
 
-    policy = <<EOF
+  policy = <<EOF
 {
     "Version": "2008-10-17",
     "Statement": [
@@ -33,7 +30,7 @@ EOF
 }
 
 module "cloudfront" {
-  source  = "../modules/cloudfront"
+  source                            = "../modules/cloudfront"
   enabled                           = var.enabled
   is_ipv6_enabled                   = var.is_ipv6_enabled
   comment                           = var.comment


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-S3-013 

 **Violation Description:** 

 To host a website on AWS S3 you should configure a bucket as a website. This policy identifies all the S3 buckets that are configured to host websites. By frequently surveying these S3 buckets you can ensure that only authorized buckets are enabled to host websites. Make sure to disable static website hosting for unauthorized S3 buckets. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket' target='_blank'>here</a>