### PR TITLE
Fixed PR-AWS-TRF-EMR-002: AWS EMR cluster is not configured with Kerberos Authentication

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -333,7 +333,7 @@ EOF
   }
 
   kerberos_attributes {
-    realm = null
+    realm = "String<The name of the Kerberos realm to which all nodes in a cluster belong. For example, EC2.INTERNAL>"
   }
 
   master_instance_group {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-EMR-002 

 **Violation Description:** 

 This policy identifies EMR clusters which are not configured with Kerberos Authentication. Kerberos uses secret-key cryptography to provide strong authentication so that passwords or other credentials aren't sent over the network in an unencrypted format. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/emr_cluster' target='_blank'>here</a>