### PR TITLE
Fixed PR-AWS-TRF-S3-021: Ensure S3 Bucket block_public_policy is enabled

### DIFF
--- a/aws/modules/s3/main.tf
+++ b/aws/modules/s3/main.tf
@@ -120,5 +120,5 @@ resource "aws_s3_bucket_public_access_block" "example" {
   bucket = aws_s3_bucket.s3_bucket.id
 
   block_public_acls   = false
-  block_public_policy = false
+  block_public_policy = true
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-S3-021 

 **Violation Description:** 

 If an AWS account is used to host a data lake or another business application, blocking public access will serve as an account-level guard against accidental public exposure. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block' target='_blank'>here</a>