### PR TITLE
Fixed PR-AWS-TRF-S3-019: Ensure S3 bucket ignore_public_acls is enabled

### DIFF
--- a/aws/modules/s3/main.tf
+++ b/aws/modules/s3/main.tf
@@ -121,4 +121,5 @@ resource "aws_s3_bucket_public_access_block" "example" {
 
   block_public_acls   = false
   block_public_policy = false
+  ignore_public_acls  = true
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-S3-020 

 **Violation Description:** 

 This will block public access granted by ACLs while still allowing PUT Object calls that include a public ACL 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block' target='_blank'>here</a>