### PR TITLE
Fixed PR-AWS-TRF-S3-018: Ensure S3 Bucket has public access blocks

### DIFF
--- a/aws/modules/s3/main.tf
+++ b/aws/modules/s3/main.tf
@@ -119,6 +119,6 @@ resource "aws_s3_bucket" "s3_bucket" {
 resource "aws_s3_bucket_public_access_block" "example" {
   bucket = aws_s3_bucket.s3_bucket.id
 
-  block_public_acls   = false
+  block_public_acls   = true
   block_public_policy = false
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-S3-018 

 **Violation Description:** 

 We recommend you ensure S3 bucket has public access blocks. If the public access block is not attached it defaults to False 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block' target='_blank'>here</a>