### PR TITLE
Fixed PR-AWS-TRF-S3-016: Ensure S3 bucket has enabled lock configuration

### DIFF
--- a/aws/msk/main.tf
+++ b/aws/msk/main.tf
@@ -39,6 +39,9 @@ resource "aws_cloudwatch_log_group" "test" {
 resource "aws_s3_bucket" "bucket" {
   bucket = "msk-broker-logs-bucket"
   acl    = "private"
+  object_lock_configuration {
+    object_lock_enabled = true
+  }
 }
 
 resource "aws_iam_role" "firehose_role" {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-S3-016 

 **Violation Description:** 

 Indicates whether this bucket has an Object Lock configuration enabled. Enable object_lock_enabled when you apply ObjectLockConfiguration to a bucket. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket' target='_blank'>here</a>