### PR TITLE
Fixed PR-AWS-TRF-S3-016: Ensure S3 bucket has enabled lock configuration

### DIFF
--- a/aws/cloudtrail/main.tf
+++ b/aws/cloudtrail/main.tf
@@ -34,10 +34,13 @@ resource "aws_s3_bucket" "s3" {
     ]
 }
 POLICY
+  object_lock_configuration {
+    object_lock_enabled = true
+  }
 }
 
 module "cloudtrail" {
-  source  = "../modules/cloudtrail"
+  source                        = "../modules/cloudtrail"
   name                          = var.name
   enable_logging                = var.enable_logging
   s3_bucket_name                = aws_s3_bucket.s3.id


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-S3-016 

 **Violation Description:** 

 Indicates whether this bucket has an Object Lock configuration enabled. Enable object_lock_enabled when you apply ObjectLockConfiguration to a bucket. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket' target='_blank'>here</a>