### PR TITLE
Fixed PR-AWS-TRF-S3-016: Ensure S3 bucket has enabled lock configuration

### DIFF
--- a/aws/modules/s3/main.tf
+++ b/aws/modules/s3/main.tf
@@ -113,6 +113,12 @@ resource "aws_s3_bucket" "s3_bucket" {
   }
 
   tags = var.tags
+  object_lock_configuration {
+    object_lock_enabled = true
+  }
+  object_lock_configuration {
+    object_lock_enabled = true
+  }
 }
 
 


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-S3-016 

 **Violation Description:** 

 Indicates whether this bucket has an Object Lock configuration enabled. Enable object_lock_enabled when you apply ObjectLockConfiguration to a bucket. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket' target='_blank'>here</a>