### PR TITLE
Fixed PR-AWS-TRF-S3-016: Ensure S3 bucket has enabled lock configuration

### DIFF
--- a/aws/s3/s3.tf
+++ b/aws/s3/s3.tf
@@ -7,6 +7,9 @@ resource "aws_s3_bucket" "a" {
     Name        = "My bucket"
     Environment = "Dev"
   }
+  object_lock_configuration {
+    object_lock_enabled = true
+  }
 }
 
 resource "aws_s3_bucket" "b" {
@@ -16,5 +19,8 @@ resource "aws_s3_bucket" "b" {
   tags = {
     Name        = "My bucket"
     Environment = "Dev"
+  }
+  object_lock_configuration {
+    object_lock_enabled = true
   }
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-S3-016 

 **Violation Description:** 

 Indicates whether this bucket has an Object Lock configuration enabled. Enable object_lock_enabled when you apply ObjectLockConfiguration to a bucket. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket' target='_blank'>here</a>