### PR TITLE
PR-AWS-TRF-S3-014: Ensure S3 hosted sites supported hardened CORS

### DIFF
--- a/aws/cloudfront/main.tf
+++ b/aws/cloudfront/main.tf
@@ -1,20 +1,20 @@
 resource "aws_s3_bucket" "s3bucket" {
-    bucket = var.bucket
-    acl = "public-read"
+  bucket = var.bucket
+  acl    = "public-read"
 
-    website {
-        redirect_all_requests_to = "index.html"
-    }
+  website {
+    redirect_all_requests_to = "index.html"
+  }
 
-    cors_rule {
-        allowed_headers = ["*"]
-        allowed_methods = ["*"]
-        allowed_origins = ["*"]
-        expose_headers = ["ETag"]
-        max_age_seconds = 3000
-    }
+  cors_rule {
+    allowed_headers = []
+    allowed_methods = []
+    allowed_origins = ["*"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
 
-    policy = <<EOF
+  policy = <<EOF
 {
     "Version": "2008-10-17",
     "Statement": [
@@ -33,7 +33,7 @@ EOF
 }
 
 module "cloudfront" {
-  source  = "../modules/cloudfront"
+  source                            = "../modules/cloudfront"
   enabled                           = var.enabled
   is_ipv6_enabled                   = var.is_ipv6_enabled
   comment                           = var.comment


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-S3-014 

 **Violation Description:** 

 Ensure that AllowedOrigins, AllowedMethods should not be set to *. this allows all cross site users to access s3 bucket and they have permission to manipulate data 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket' target='_blank'>here</a>