### PR TITLE
Fixed PR-AWS-TRF-RSH-002: AWS Redshift clusters should not be publicly accessible

### DIFF
--- a/aws/redshift/terraform.tfvars
+++ b/aws/redshift/terraform.tfvars
@@ -8,7 +8,7 @@ cluster_port                        = 5439
 vpc_security_group_ids              = []
 redshift_subnet_group_name          = ""
 parameter_group_name                = ""
-publicly_accessible                 = true
+publicly_accessible                 = false
 snapshot_identifier                 = null
 snapshot_cluster_identifier         = null
 owner_account                       = null
@@ -26,13 +26,13 @@ enable_logging                      = false
 logging_bucket_name                 = null
 logging_s3_key_prefix               = null
 
-parameter_name                      = "prancer-redshift-params"
-parameter_family                    = "redshift-1.0"
-parameter_map                       = {
+parameter_name   = "prancer-redshift-params"
+parameter_family = "redshift-1.0"
+parameter_map = {
   require_ssl = "false"
 }
 
-tags                                = {
+tags = {
   environment = "Production"
-  project = "Prancer"
+  project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-RSH-002 

 **Violation Description:** 

 This policy identifies AWS Redshift clusters which are accessible publicly. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster' target='_blank'>here</a>