### PR TITLE
Fixed PR-AWS-TRF-RSH-004: AWS Redshift instances are not encrypted

### DIFF
--- a/aws/redshift/terraform.tfvars
+++ b/aws/redshift/terraform.tfvars
@@ -19,20 +19,20 @@ preferred_maintenance_window        = "sun:03:00-sun:05:00"
 allow_version_upgrade               = false
 snapshot_copy_destination_region    = null
 cluster_iam_roles                   = []
-encrypted                           = false
+encrypted                           = true
 kms_key_id                          = ""
 enhanced_vpc_routing                = false
 enable_logging                      = false
 logging_bucket_name                 = null
 logging_s3_key_prefix               = null
 
-parameter_name                      = "prancer-redshift-params"
-parameter_family                    = "redshift-1.0"
-parameter_map                       = {
+parameter_name   = "prancer-redshift-params"
+parameter_family = "redshift-1.0"
+parameter_map = {
   require_ssl = "false"
 }
 
-tags                                = {
+tags = {
   environment = "Production"
-  project = "Prancer"
+  project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-RSH-004 

 **Violation Description:** 

 This policy identifies AWS Redshift instances which are not encrypted. These instances should be encrypted for clusters to help protect data at rest which otherwise can result in a data breach. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster' target='_blank'>here</a>