### PR TITLE
Fixed PR-AWS-TRF-RSH-005: Ensure Redshift cluster allow version upgrade by default

### DIFF
--- a/aws/redshift/terraform.tfvars
+++ b/aws/redshift/terraform.tfvars
@@ -16,7 +16,7 @@ final_snapshot_identifier           = null
 skip_final_snapshot                 = true
 automated_snapshot_retention_period = 0
 preferred_maintenance_window        = "sun:03:00-sun:05:00"
-allow_version_upgrade               = false
+allow_version_upgrade               = true
 snapshot_copy_destination_region    = null
 cluster_iam_roles                   = []
 encrypted                           = false
@@ -26,13 +26,13 @@ enable_logging                      = false
 logging_bucket_name                 = null
 logging_s3_key_prefix               = null
 
-parameter_name                      = "prancer-redshift-params"
-parameter_family                    = "redshift-1.0"
-parameter_map                       = {
+parameter_name   = "prancer-redshift-params"
+parameter_family = "redshift-1.0"
+parameter_map = {
   require_ssl = "false"
 }
 
-tags                                = {
+tags = {
   environment = "Production"
-  project = "Prancer"
+  project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-RSH-005 

 **Violation Description:** 

 This policy identifies AWS Redshift instances which has not enabled AllowVersionUpgrade. major version upgrades can be applied during the maintenance window to the Amazon Redshift engine that is running on the cluster. When a new major version of the Amazon Redshift engine is released, you can request that the service automatically apply upgrades during the maintenance window to the Amazon Redshift engine that is running on your cluster. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster' target='_blank'>here</a>