### PR TITLE
Fixed PR-AWS-TRF-ACM-002: AWS Certificate Manager (ACM) has certificates with Certificate Transparency Logging disabled

### DIFF
--- a/aws/acm/terraform.tfvars
+++ b/aws/acm/terraform.tfvars
@@ -1,10 +1,10 @@
 domain_name               = "*.test.prancer.io"
 validation_method         = "EMAIL"
 subject_alternative_names = ["www.test.prancer.io"]
-transparency              = "DISABLED"
+transparency              = "ENABLED"
 
 tags = {
-  Name = "prancer-ec2"
+  Name        = "prancer-ec2"
   Environment = "Production"
-  Project = "Prancer"
+  Project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-ACM-002 

 **Violation Description:** 

 This policy identifies AWS Certificate Manager certificates in which Certificate Transparency Logging is disabled. AWS Certificate Manager (ACM) is the preferred tool to provision, manage, and deploy your server certificates. Certificate Transparency Logging is used to guard against SSL/TLS certificates that are issued by mistake or by a compromised CA, some browsers require that public certificates issued for your domain can also be recorded. This policy generates alerts for certificates which have transparency logging disabled. As a best practice, it is recommended to enable Transparency logging for all certificates. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate' target='_blank'>here</a>