### PR TITLE
Fixed PR-AWS-TRF-ECR-001: Ensure ECR image tags are immutable

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -297,7 +297,7 @@ resource "aws_api_gateway_request_validator" "example" {
 
 resource "aws_ecr_repository" "foo" {
   name                 = "bar"
-  image_tag_mutability = "MUTABLE"
+  image_tag_mutability = "IMMUTABLE"
 
   image_scanning_configuration {
     scan_on_push = true


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-ECR-001 

 **Violation Description:** 

 Amazon ECR supports immutable tags, preventing image tags from being overwritten. In the past, ECR tags could have been overwritten, this could be overcome by requiring users to uniquely identify an image using a naming convention.Tag Immutability enables users can rely on the descriptive tags of an image as a mechanism to track and uniquely identify images. By setting an image tag as immutable, developers can use the tag to correlate the deployed image version with the build that produced the image. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository' target='_blank'>here</a>