### PR TITLE
PR-AWS-TRF-EC2-003: AWS EC2 instances with Public IP and associated with Security Groups have Internet Access

### DIFF
--- a/aws/modules/ec2/main.tf
+++ b/aws/modules/ec2/main.tf
@@ -21,7 +21,7 @@ resource "aws_instance" "ec2" {
   private_ip                  = length(var.private_ips) > 0 ? element(var.private_ips, count.index) : var.private_ip
   ipv6_address_count          = var.ipv6_address_count
   ipv6_addresses              = var.ipv6_addresses
-  security_groups             = ["default"]
+  security_groups             = []
 
   ebs_optimized = var.ebs_optimized
 


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-EC2-003 

 **Violation Description:** 

 This policy identifies AWS EC2 instances with Public IP and associated with Security Groups have Internet Access. EC2 instance receives a public IP address when launched in a default VPC security group (A security group acts as a virtual firewall for your instance to control inbound and outbound traffic.) and we don't assign a public IP address to instances launched in a non-default subnet. Therefore it's a best practice to ensure that there are no EC2 instances with Public IP that are associated with Security Groups which have Internet Access. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance' target='_blank'>here</a>