### PR TITLE
Fixed PR-AWS-TRF-EC2-004: Ensure that EC2 instace is EBS Optimized

### DIFF
--- a/aws/ec2/terraform.tfvars
+++ b/aws/ec2/terraform.tfvars
@@ -12,7 +12,7 @@ subnet_id                            = ""
 associate_public_ip_address          = true
 ipv6_address_count                   = null
 ipv6_addresses                       = null
-ebs_optimized                        = false
+ebs_optimized                        = true
 root_block_device                    = []
 ebs_block_device                     = []
 ephemeral_block_device               = []
@@ -22,12 +22,12 @@ instance_initiated_shutdown_behavior = "stop"
 placement_group                      = null
 tenancy                              = null
 
-availability_zone                    = "us-east-2a"
-encrypted                            = false
-size                                 = 5
+availability_zone = "us-east-2a"
+encrypted         = false
+size              = 5
 
 tags = {
-  Name = "prancer-ec2"
+  Name        = "prancer-ec2"
   Environment = "Production"
-  Project = "Prancer"
+  Project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-EC2-004 

 **Violation Description:** 

 Enable ebs_optimized provides dedicated throughput to Amazon EBS and an optimized configuration stack to provide optimal Amazon EBS I/O performance 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance' target='_blank'>here</a>