### PR TITLE
Fixed PR-AWS-TRF-EC2-004: Ensure that EC2 instace is EBS Optimized

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -875,8 +875,9 @@ resource "aws_instance" "foo" {
   ami           = "ami-5189a661"
   instance_type = "t2.micro"
 
-  private_ip = "10.0.0.12"
-  subnet_id  = aws_subnet.tf_test_subnet.id
+  private_ip    = "10.0.0.12"
+  subnet_id     = aws_subnet.tf_test_subnet.id
+  ebs_optimized = true
 }
 
 resource "aws_eip" "bar" {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-EC2-004 

 **Violation Description:** 

 Enable ebs_optimized provides dedicated throughput to Amazon EBS and an optimized configuration stack to provide optimal Amazon EBS I/O performance 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance' target='_blank'>here</a>