### PR TITLE
Fixed PR-AWS-TRF-EC2-004: Ensure that EC2 instace is EBS Optimized

### DIFF
--- a/aws/sg/extrasg.tf
+++ b/aws/sg/extrasg.tf
@@ -338,4 +338,5 @@ resource "aws_instance" "web" {
 
   }
 
+  ebs_optimized = true
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-EC2-004 

 **Violation Description:** 

 Enable ebs_optimized provides dedicated throughput to Amazon EBS and an optimized configuration stack to provide optimal Amazon EBS I/O performance 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance' target='_blank'>here</a>