### PR TITLE
Fixed PR-AWS-TRF-EC2-005: Ensure detailed monitoring is enabled for EC2 instances

### DIFF
--- a/aws/ec2/terraform.tfvars
+++ b/aws/ec2/terraform.tfvars
@@ -4,7 +4,7 @@ instance_type                        = "t3.micro"
 user_data                            = null
 user_data_base64                     = null
 key_name                             = ""
-monitoring                           = false
+monitoring                           = true
 get_password_data                    = false
 vpc_security_group_ids               = []
 iam_instance_profile                 = null
@@ -22,12 +22,12 @@ instance_initiated_shutdown_behavior = "stop"
 placement_group                      = null
 tenancy                              = null
 
-availability_zone                    = "us-east-2a"
-encrypted                            = false
-size                                 = 5
+availability_zone = "us-east-2a"
+encrypted         = false
+size              = 5
 
 tags = {
-  Name = "prancer-ec2"
+  Name        = "prancer-ec2"
   Environment = "Production"
-  Project = "Prancer"
+  Project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-EC2-005 

 **Violation Description:** 

 Ensure that detailed monitoring is enabled for your Amazon EC2 instances in order to have enough monitoring data to help you make better decisions on architecting and managing compute resources within your AWS account 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance' target='_blank'>here</a>