### PR TITLE
Fixed PR-AWS-TRF-EC2-005: Ensure detailed monitoring is enabled for EC2 instances

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -877,6 +877,7 @@ resource "aws_instance" "foo" {
 
   private_ip = "10.0.0.12"
   subnet_id  = aws_subnet.tf_test_subnet.id
+  monitoring = true
 }
 
 resource "aws_eip" "bar" {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-EC2-005 

 **Violation Description:** 

 Ensure that detailed monitoring is enabled for your Amazon EC2 instances in order to have enough monitoring data to help you make better decisions on architecting and managing compute resources within your AWS account 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance' target='_blank'>here</a>