### PR TITLE
Fixed PR-AWS-TRF-EC2-005: Ensure detailed monitoring is enabled for EC2 instances

### DIFF
--- a/aws/sg/extrasg.tf
+++ b/aws/sg/extrasg.tf
@@ -338,4 +338,5 @@ resource "aws_instance" "web" {
 
   }
 
+  monitoring = true
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-EC2-005 

 **Violation Description:** 

 Ensure that detailed monitoring is enabled for your Amazon EC2 instances in order to have enough monitoring data to help you make better decisions on architecting and managing compute resources within your AWS account 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance' target='_blank'>here</a>