### PR TITLE
Fixed PR-AWS-TRF-ECS-008: Ensure container insights are enabled on ECS cluster

### DIFF
--- a/aws/modules/ecs/main.tf
+++ b/aws/modules/ecs/main.tf
@@ -3,7 +3,7 @@ resource "aws_ecs_cluster" "ecs" {
 
   setting {
     name  = "containerInsights"
-    value = var.enable_container_insights ? "enabled" : "disabled"
+    value = "enabled"
   }
 
   tags = var.tags


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-ECS-008 

 **Violation Description:** 

 Container Insights can be used to collect, aggregate, and summarize metrics and logs from containerized applications and microservices. They can also be extended to collect metrics at the cluster, task, and service levels. Using Container Insights allows you to monitor, troubleshoot, and set alarms for all your Amazon ECS resources. It provides a simple to use native and fully managed service for managing ECS issues. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster' target='_blank'>here</a>