### PR TITLE
Fixed PR-AWS-TRF-ECS-010: Ensure that ECS Service and Task Set network configuration disallows the assignment of public IPs

### DIFF
--- a/aws/modules/ecs/main.tf
+++ b/aws/modules/ecs/main.tf
@@ -27,7 +27,7 @@ resource "aws_ecs_service" "mongo" {
   network_configuration {
     subnets          = []
     security_groups  = []
-    assign_public_ip = true
+    assign_public_ip = false
   }
 
   load_balancer {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-ECS-010 

 **Violation Description:** 

 Ensure that the ecs service and Task Set Network has set [AssignPublicIp/assign_public_ip] property is set to DISABLED else an Actor can exfiltrate data by associating ECS resources with non-ADATUM resources 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#network_configuration' target='_blank'>here</a>