### PR TITLE
Fixed PR-AWS-TRF-ECS-011: Ensure that ECS services and Task Sets are launched as Fargate type

### DIFF
--- a/aws/modules/ecs/main.tf
+++ b/aws/modules/ecs/main.tf
@@ -17,7 +17,7 @@ resource "aws_ecs_service" "mongo" {
   iam_role               = aws_iam_role.foo.arn
   depends_on             = [aws_iam_role_policy.foo]
   enable_execute_command = true
-  launch_type            = "EC2"
+  launch_type            = "FARGATE"
 
   ordered_placement_strategy {
     type  = "binpack"


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-ECS-011 

 **Violation Description:** 

 Ensure that ECS services and Task Sets are launched as Fargate type else Actor can launch ECS service into an unsafe configuration allowing for external exposure or unaccounted for configurations. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#launch_type' target='_blank'>here</a>