### PR TITLE
Fixed PR-AWS-TRF-LMD-003: AWS Lambda functions with tracing not enabled

### DIFF
--- a/aws/lambda/terraform.tfvars
+++ b/aws/lambda/terraform.tfvars
@@ -19,13 +19,13 @@ assume_role_policy            = <<EOF
 }
 EOF
 
-cidr_block                      = "10.10.0.0/16"
-instance_tenancy                = "default"
-enable_dns_hostnames            = false
-enable_dns_support              = true
-enable_classiclink              = null
-enable_classiclink_dns_support  = null
-enable_ipv6                     = false
+cidr_block                     = "10.10.0.0/16"
+instance_tenancy               = "default"
+enable_dns_hostnames           = false
+enable_dns_support             = true
+enable_classiclink             = null
+enable_classiclink_dns_support = null
+enable_ipv6                    = false
 
 subnet_cidr_block               = "10.10.1.0/24"
 availability_zone               = null
@@ -34,12 +34,12 @@ map_public_ip_on_launch         = false
 assign_ipv6_address_on_creation = false
 ipv6_cidr_block                 = null
 
-sgroup_name                     = "prancer-security-group"
-sgroup_description              = "Prancer Security Group"
-revoke_rules_on_delete          = false
+sgroup_name            = "prancer-security-group"
+sgroup_description     = "Prancer Security Group"
+revoke_rules_on_delete = false
 
-description                    = ""
-environment                    = {
+description = ""
+environment = {
   variables = {
     API_KEY = "3c3ac97c6fa1850d366b70fbcd49a3db"
   }
@@ -56,9 +56,9 @@ s3_bucket                      = ""
 s3_key                         = ""
 s3_object_version              = ""
 timeout                        = 5
-tracing_mode                   = "PassThrough"
+tracing_mode                   = "Active"
 
 tags = {
   environment = "Production"
-  project = "Prancer"
+  project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-LMD-003 

 **Violation Description:** 

 TracingConfig is a property of the AWS::Lambda::Function resource that configures tracing settings for your AWS Lambda (Lambda) function. When enabled, AWS Lambda tracing acitivates AWS X-Ray service that collects information on requests that a specific function performed. It reduces the time and effort for debugging and diagnosing the errors.<br><br>The value can be either PassThrough or Active. If PassThrough, Lambda will only trace the request from an upstream service if it contains a tracing header with 'sampled=1'. If Active, Lambda will respect any tracing header it receives from an upstream service. If no tracing header is received, Lambda will call X-Ray for a tracing decision. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function' target='_blank'>here</a>