### PR TITLE
Fixed PR-AWS-TRF-LMD-003: AWS Lambda functions with tracing not enabled

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -546,6 +546,9 @@ resource "aws_lambda_function" "authorizer" {
   handler       = "exports.example"
 
   source_code_hash = filebase64sha256("lambda-function.zip")
+  tracing_config {
+    mode = "Active"
+  }
 }
 
 resource "aws_elb" "main" {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-LMD-003 

 **Violation Description:** 

 TracingConfig is a property of the AWS::Lambda::Function resource that configures tracing settings for your AWS Lambda (Lambda) function. When enabled, AWS Lambda tracing acitivates AWS X-Ray service that collects information on requests that a specific function performed. It reduces the time and effort for debugging and diagnosing the errors.<br><br>The value can be either PassThrough or Active. If PassThrough, Lambda will only trace the request from an upstream service if it contains a tracing header with 'sampled=1'. If Active, Lambda will respect any tracing header it receives from an upstream service. If no tracing header is received, Lambda will call X-Ray for a tracing decision. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function' target='_blank'>here</a>