### PR TITLE
Fixed PR-AWS-TRF-RDS-001: AWS RDS DB cluster encryption is disabled

### DIFF
--- a/aws/rds/terraform.tfvars
+++ b/aws/rds/terraform.tfvars
@@ -4,7 +4,7 @@ cluster_master_password     = "c9209030ffc53a3fa5663955f65a85de"
 cluster_master_username     = "dbadm"
 cluster_skip_final_snapshot = true
 cluster_kms_key_id          = null
-cluster_storage_encrypted   = false
+cluster_storage_encrypted   = true
 
 identifier                            = "prancer-rds"
 engine                                = "mysql"


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-RDS-001 

 **Violation Description:** 

 This policy identifies RDS DB clusters for which encryption is disabled. Amazon Aurora encrypted DB clusters provide an additional layer of data protection by securing your data from unauthorized access to the underlying storage. You can use Amazon Aurora encryption to increase data protection of your applications deployed in the cloud, and to fulfill compliance requirements for data-at-rest encryption._x005F_x000D_ NOTE: This policy is applicable only for Aurora DB clusters._x005F_x000D_ https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-clusters.html 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster' target='_blank'>here</a>