### PR TITLE
Fixed PR-AWS-TRF-DD-001: AWS DynamoDB encrypted using AWS owned CMK instead of AWS managed CMK

### DIFF
--- a/aws/dynamodb/terraform.tfvars
+++ b/aws/dynamodb/terraform.tfvars
@@ -1,10 +1,10 @@
-name                = "prancer-dynamodb"
-hash_key            = "HashKey"
-range_key           = "RangeKey"
-enabled             = true
-billing_mode        = "PROVISIONED"
-enable_streams      = true
-enable_encryption   = false
+name              = "prancer-dynamodb"
+hash_key          = "HashKey"
+range_key         = "RangeKey"
+enabled           = true
+billing_mode      = "PROVISIONED"
+enable_streams    = true
+enable_encryption = true
 dynamodb_attributes = [
   {
     name = "PersonalID"
@@ -57,7 +57,7 @@ global_secondary_index_map = [
   }
 ]
 
-tags                  = {
+tags = {
   environmet = "Production"
   project    = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-DD-001 

 **Violation Description:** 

 This policy identifies the DynamoDB tables that use AWS owned CMK (default ) instead of AWS managed CMK (KMS ) to encrypt data. AWS managed CMK provide additional features such as the ability to view the CMK and key policy, and audit the encryption and decryption of DynamoDB tables. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table' target='_blank'>here</a>