### PR TITLE
Fixed PR-AWS-TRF-CF-008: AWS CloudFront web distribution with default SSL certificate

### DIFF
--- a/aws/modules/cloudfront/main.tf
+++ b/aws/modules/cloudfront/main.tf
@@ -45,7 +45,7 @@ resource "aws_cloudfront_distribution" "cloudfront" {
     acm_certificate_arn            = var.acm_certificate_arn
     ssl_support_method             = "sni-only"
     minimum_protocol_version       = var.viewer_minimum_protocol_version
-    cloudfront_default_certificate = var.acm_certificate_arn == "" ? true : false
+    cloudfront_default_certificate = false
   }
 
   default_cache_behavior {
@@ -86,4 +86,7 @@ resource "aws_cloudfront_distribution" "cloudfront" {
 
 resource "aws_cloudfront_distribution" "cloudfront_null" {
 
+  viewer_certificate {
+    cloudfront_default_certificate = false
+  }
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-CF-008 

 **Violation Description:** 

 This policy identifies CloudFront web distributions which have a default SSL certificate to access CloudFront content. It is a best practice to use custom SSL Certificate to access CloudFront content. It gives you full control over the content data. custom SSL certificates also allow your users to access your content by using an alternate domain name. You can use a certificate stored in AWS Certificate Manager (ACM) or you can use a certificate stored in IAM. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution' target='_blank'>here</a>