### PR TITLE
Fixed PR-AWS-TRF-CF-006: AWS CloudFront web distribution that allow TLS versions 1.0 or lower

### DIFF
--- a/aws/cloudfront/terraform.tfvars
+++ b/aws/cloudfront/terraform.tfvars
@@ -21,7 +21,7 @@ origin_keepalive_timeout          = 60
 origin_read_timeout               = 60
 origin_access_identity            = ""
 acm_certificate_arn               = ""
-viewer_minimum_protocol_version   = "TLSv1"
+viewer_minimum_protocol_version   = "TLSv1.2_2021"
 allowed_methods                   = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
 cached_methods                    = ["GET", "HEAD"]
 compress                          = false
@@ -40,5 +40,5 @@ geo_restriction_locations         = []
 
 tags = {
   Environment = "Production"
-  Project = "Prancer"
+  Project     = "Prancer"
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-CF-006 

 **Violation Description:** 

 This policy identifies AWS CloudFront web distributions which are configured with TLS versions for HTTPS communication between viewers and CloudFront. As a best practice, use TLSv1.1_2016 or later as the minimum protocol version in your CloudFront distribution security policies. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution' target='_blank'>here</a>