### PR TITLE
Fixed PR-AWS-TRF-RDS-017: Ensure RDS instace has IAM authentication enabled

### DIFF
--- a/aws/rds/terraform.tfvars
+++ b/aws/rds/terraform.tfvars
@@ -21,7 +21,7 @@ password                              = "otObicedfobgurEydHef9ofEfjalvib="
 port                                  = 3306
 domain                                = ""
 domain_iam_role_name                  = ""
-iam_database_authentication_enabled   = false
+iam_database_authentication_enabled   = true
 replicate_source_db                   = ""
 snapshot_identifier                   = ""
 vpc_security_group_ids                = []


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-RDS-017 

 **Violation Description:** 

 Ensure IAM Database Authentication feature is enabled in order to use AWS Identity and Access Management (IAM) service to manage database access to your Amazon RDS MySQL and PostgreSQL instances. With this feature enabled, you don't have to use a password when you connect to your MySQL/PostgreSQL database instances, instead you use an authentication token 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance' target='_blank'>here</a>