### PR TITLE
Fixed PR-AWS-TRF-RDS-015: AWS RDS Global DB cluster encryption is disabled

### DIFF
--- a/aws/modules/rds/main.tf
+++ b/aws/modules/rds/main.tf
@@ -73,7 +73,7 @@ resource "aws_db_event_subscription" "default-db-security-group" {
   sns_topic = aws_sns_topic.default.arn
 
   source_type = "db-security-group"
-  enabled = false
+  enabled     = false
 
   event_categories = [
     "availability",
@@ -96,7 +96,7 @@ resource "aws_db_event_subscription" "default-db-instance" {
 
   source_type = "db-instance"
   source_ids  = [aws_db_instance.rds.id]
-  enabled = false
+  enabled     = false
 
   event_categories = [
     "availability",
@@ -132,5 +132,5 @@ resource "aws_rds_global_cluster" "example" {
   engine                    = "aurora"
   engine_version            = "5.6.mysql_aurora.1.22.2"
   database_name             = "example_db"
-  storage_encrypted         = false
+  storage_encrypted         = true
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-RDS-015 

 **Violation Description:** 

 This policy identifies RDS Global DB clusters for which encryption is disabled. Amazon Aurora encrypted Global DB clusters provide an additional layer of data protection by securing your data from unauthorized access to the underlying storage. You can use Amazon Aurora encryption to increase data protection of your applications deployed in the cloud, and to fulfill compliance requirements 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_global_cluster' target='_blank'>here</a>