### PR TITLE
Fixed PR-AWS-TRF-DMS-002: Ensure DMS replication instance is not publicly accessible

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -762,7 +762,7 @@ resource "aws_dms_replication_instance" "test" {
   kms_key_arn                  = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
   multi_az                     = false
   preferred_maintenance_window = "sun:10:30-sun:14:30"
-  publicly_accessible          = true
+  publicly_accessible          = false
   replication_instance_class   = "dms.t2.micro"
   replication_instance_id      = "test-dms-replication-instance-tf"
   replication_subnet_group_id  = aws_dms_replication_subnet_group.test-dms-replication-subnet-group-tf.id


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-DMS-002 

 **Violation Description:** 

 Ensure DMS replication instance is not publicly accessible, this might cause sensitive data leak. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_instance' target='_blank'>here</a>