### PR TITLE
Fixed PR-AWS-TRF-RDS-013: Ensure RDS clusters and instances have deletion protection enabled

### DIFF
--- a/aws/modules/rdsCluster/main.tf
+++ b/aws/modules/rdsCluster/main.tf
@@ -1,10 +1,11 @@
 resource "aws_rds_cluster" "rdscluster" {
-  cluster_identifier   = var.cluster_identifier
-  engine_mode          = var.cluster_engine_mode
-  master_password      = var.cluster_master_password
-  master_username      = var.cluster_master_username
-  skip_final_snapshot  = var.cluster_skip_final_snapshot
-  kms_key_id           = var.cluster_kms_key_id
-  storage_encrypted    = var.cluster_storage_encrypted
+  cluster_identifier      = var.cluster_identifier
+  engine_mode             = var.cluster_engine_mode
+  master_password         = var.cluster_master_password
+  master_username         = var.cluster_master_username
+  skip_final_snapshot     = var.cluster_skip_final_snapshot
+  kms_key_id              = var.cluster_kms_key_id
+  storage_encrypted       = var.cluster_storage_encrypted
   backup_retention_period = var.cluster_backup_retention_period
+  deletion_protection     = true
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-RDS-013 

 **Violation Description:** 

 This rule Checks if an Amazon Relational Database Service (Amazon RDS) cluster has deletion protection enabled 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster' target='_blank'>here</a>