### PR TITLE
Fixed PR-AWS-TRF-DDB-004: Ensure DocDB has audit logs enabled

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -705,7 +705,7 @@ resource "aws_docdb_cluster_parameter_group" "example" {
 
   parameter {
     name  = "audit_logs"
-    value = "disabled"
+    value = "enabled"
   }
 
 }


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-DDB-004 

 **Violation Description:** 

 Ensure DocDB has audit logs enabled, this will export logs in docdb 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster_parameter_group' target='_blank'>here</a>