### PR TITLE
Fixed PR-AWS-TRF-DDB-003: Ensure DocDB ParameterGroup has TLS enable

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -700,7 +700,7 @@ resource "aws_docdb_cluster_parameter_group" "example" {
 
   parameter {
     name  = "tls"
-    value = "disabled"
+    value = "enabled"
   }
 
   parameter {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-DDB-003 

 **Violation Description:** 

 TLS can be used to encrypt the connection between an application and a DocDB cluster. By default, encryption in transit is enabled for newly created clusters. It can optionally be disabled when the cluster is created, or at a later time. When enabled, secure connections using TLS are required to connect to the cluster. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster_parameter_group' target='_blank'>here</a>