### PR TITLE
Fixed PR-AWS-TRF-DDB-001: Ensure DocumentDB cluster is encrypted at rest

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -689,7 +689,7 @@ resource "aws_docdb_cluster" "docdb" {
   backup_retention_period         = 5
   preferred_backup_window         = "07:00-09:00"
   skip_final_snapshot             = true
-  storage_encrypted               = false
+  storage_encrypted               = true
   enabled_cloudwatch_logs_exports = false
 }
 


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-DDB-001 

 **Violation Description:** 

 Ensure that encryption is enabled for your AWS DocumentDB (with MongoDB compatibility) clusters for additional data security and in order to meet compliance requirements for data-at-rest encryption 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster' target='_blank'>here</a>