### PR TITLE
Fixed PR-AWS-TRF-QLDB-001: Ensure QLDB ledger permissions mode is set to STANDARD

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -600,7 +600,7 @@ resource "aws_dax_cluster" "bar" {
 
 resource "aws_qldb_ledger" "sample-ledger" {
   name             = "sample-ledger"
-  permissions_mode = "ALLOW_ALL"
+  permissions_mode = "STANDARD"
 }
 
 resource "aws_codebuild_project" "project-with-cache" {


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-QLDB-001 

 **Violation Description:** 

 In Amazon Quantum Ledger Database define PermissionsMode value to STANDARD permissions mode that enables access control with finer granularity for ledgers, tables, and PartiQL commands 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/qldb_ledger' target='_blank'>here</a>