### PR TITLE
Fixed PR-AWS-TRF-DAX-001: Ensure DAX is securely encrypted at rest

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -594,7 +594,7 @@ resource "aws_dax_cluster" "bar" {
   replication_factor = 1
 
   server_side_encryption {
-    enabled = false
+    enabled = true
   }
 }
 


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-DAX-001 

 **Violation Description:** 

 Amazon DynamoDB Accelerator (DAX) encryption at rest provides an additional layer of data protection, helping secure your data from unauthorized access to underlying storage. With encryption at rest the data persisted by DAX on disk is encrypted using 256-bit Advanced Encryption Standard (AES-256). DAX writes data to disk as part of propagating changes from the primary node to read replicas. DAX encryption at rest automatically integrates with AWS KMS for managing the single service default key used to encrypt clusters. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dax_cluster' target='_blank'>here</a>