### PR TITLE
Fixed PR-AWS-TRF-RDS-012: AWS RDS cluster retention policy less than 7 days

### DIFF
--- a/aws/rds/terraform.tfvars
+++ b/aws/rds/terraform.tfvars
@@ -49,7 +49,7 @@ backup_window                         = "05:05-07:05"
 timezone                              = ""
 enabled_cloudwatch_logs_exports       = []
 deletion_protection                   = false
-cluster_backup_retention_period       = 0
+cluster_backup_retention_period       = 7
 timeouts = {
   "create" : "40m",
   "delete" : "40m",


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-RDS-012 

 **Violation Description:** 

 RDS cluster Retention Policies for Backups are an important part of your DR/BCP strategy. Recovering data from catastrophic failures, malicious attacks, or corruption often requires a several day window of potentially good backup material to leverage. As such, the best practice is to ensure your RDS clusters are retaining at least 7 days of backups, if not more (up to a maximum of 35). 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster' target='_blank'>here</a>