### PR TITLE
Fixed PR-AWS-TRF-RDS-005: AWS RDS event subscription disabled for DB security groups

### DIFF
--- a/aws/modules/rds/main.tf
+++ b/aws/modules/rds/main.tf
@@ -73,7 +73,7 @@ resource "aws_db_event_subscription" "default-db-security-group" {
   sns_topic = aws_sns_topic.default.arn
 
   source_type = "db-security-group"
-  enabled = false
+  enabled     = true
 
   event_categories = [
     "availability",
@@ -96,7 +96,7 @@ resource "aws_db_event_subscription" "default-db-instance" {
 
   source_type = "db-instance"
   source_ids  = [aws_db_instance.rds.id]
-  enabled = false
+  enabled     = false
 
   event_categories = [
     "availability",


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-RDS-005 

 **Violation Description:** 

 This policy identifies RDS event subscriptions for which DB security groups event subscription is disabled. You can create an Amazon RDS event notification subscription so that you can be notified when an event occurs for given DB security groups. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_event_subscription' target='_blank'>here</a>