### PR TITLE
Fixed PR-AZR-TRF-VM-007: Azure Windows Instance should not allow extension operation

### DIFF
--- a/azure/vm/vm_group/main.tf
+++ b/azure/vm/vm_group/main.tf
@@ -42,9 +42,9 @@ resource "azurerm_network_interface" "main" {
 }
 
 resource "azurerm_network_interface" "internal" {
-  name                      = "${var.prefix}-nic2"
-  resource_group_name       = azurerm_resource_group.main.name
-  location                  = azurerm_resource_group.main.location
+  name                = "${var.prefix}-nic2"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
 
   ip_configuration {
     name                          = "internal"
@@ -127,12 +127,12 @@ resource "azurerm_linux_virtual_machine" "slave" {
 }
 
 resource "azurerm_windows_virtual_machine" "main" {
-  name                            = "${var.prefix}-vm"
-  resource_group_name             = azurerm_resource_group.main.name
-  location                        = azurerm_resource_group.main.location
-  size                            = "Standard_DS3_v2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@ssw0rd1234!"
+  name                = "${var.prefix}-vm"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  size                = "Standard_DS3_v2"
+  admin_username      = "adminuser"
+  admin_password      = "P@ssw0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.main.id,
   ]
@@ -152,6 +152,7 @@ resource "azurerm_windows_virtual_machine" "main" {
       option = "Local"
     }
   }
+  allow_extension_operations = false
 }
 
 resource "azurerm_virtual_machine_extension" "test" {


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-VM-007 

 **Violation Description:** 

 For security purpose, windows vm extension operation should be disabled. 

 **How to Fix:** 

 In 'azurerm_windows_virtual_machine' resource, make sure to set 'allow_extension_operations = false' to fix the issue. Please visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_virtual_machine#allow_extension_operations' target='_blank'>here</a> for details.