### PR TITLE
Fixed PR-AWS-TRF-CP-001: Code Pipeline Encryption at rest with customer-managed key (CMK) should be enabled

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -17,7 +17,7 @@ resource "aws_codepipeline" "codepipeline" {
 
     encryption_key {
       id   = data.aws_kms_alias.s3kmskey.arn
-      type = ""
+      type = "KMS"
     }
   }
 


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-CP-001 

 **Violation Description:** 

 The type of encryption key When creating or updating a pipeline, the value must be cmk(customer-managed key) 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codepipeline' target='_blank'>here</a>