### PR TITLE
Fixed PR-AWS-TRF-S3-007: AWS S3 Object Versioning is disabled

### DIFF
--- a/aws/common/main.tf
+++ b/aws/common/main.tf
@@ -88,6 +88,10 @@ resource "aws_codestarconnections_connection" "example" {
 resource "aws_s3_bucket" "codepipeline_bucket" {
   bucket = "test-bucket"
   acl    = "private"
+
+  versioning {
+    enabled = true
+  }
 }
 
 resource "aws_iam_role" "codepipeline_role" {
@@ -1171,7 +1175,7 @@ resource "aws_iam_role" "test_role" {
         Principal = {
           Service = ["ec2.amazonaws.com", "lambda:amazonaws.com", "secretmanager.amazonaws.com", "sqs.amazonaws.com"]
         }
-        Resource = "*", 
+        Resource = "*",
         Condition = {
           "IpAddress" : {
             "aws:SourceIp" : "0.0.0.0/0"
@@ -1214,9 +1218,9 @@ resource "aws_vpc_endpoint" "vpc-policy" {
         Action = [
           "*",
         ]
-        Effect   = "Allow"
-        Resource = "*"
-        Principal =  "*"
+        Effect    = "Allow"
+        Resource  = "*"
+        Principal = "*"
       }
     ]
   })


### PR DESCRIPTION
**Violation Id:** PR-AWS-TRF-S3-007 

 **Violation Description:** 

 This policy identifies the S3 buckets which have Object Versioning disabled. S3 Object Versioning is an important capability in protecting your data within a bucket. Once you enable Object Versioning, you cannot remove it; you can suspend Object Versioning at any time on a bucket if you do not wish for it to persist. It is recommended to enable Object Versioning on S3. 

 **How to Fix:** 

 Make sure you are following the Terraform template format presented <a href='https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket' target='_blank'>here</a>