### PR TITLE
Fixed PR-AZR-TRF-AGW-005: Ensure Application Gateway Backend is using Https protocol

### DIFF
--- a/azure/applicationgateways/terraform.tfvars
+++ b/azure/applicationgateways/terraform.tfvars
@@ -1,19 +1,19 @@
-location              = "eastus2"
-vnet_name             = "prancer-vnet"
-resource_group        = "prancer-test-rg"
-address_space         = "10.254.0.0/16"
-dns_server            = "10.254.0.1"
+location       = "eastus2"
+vnet_name      = "prancer-vnet"
+resource_group = "prancer-test-rg"
+address_space  = "10.254.0.0/16"
+dns_server     = "10.254.0.1"
 
-subnet_name_fe        = "prancer-frontend"
-address_prefixes_fe   = ["10.254.0.0/24"]
+subnet_name_fe      = "prancer-frontend"
+address_prefixes_fe = ["10.254.0.0/24"]
 
-subnet_name_be        = "prancer-backend"
-address_prefixes_be   = ["10.254.2.0/24"]
+subnet_name_be      = "prancer-backend"
+address_prefixes_be = ["10.254.2.0/24"]
 
-pip_name              = "prancer-pip"
-pip_type              = "Dynamic"
-pip_sku               = "Basic"
-ip_version            = "IPv4"
+pip_name   = "prancer-pip"
+pip_type   = "Dynamic"
+pip_sku    = "Basic"
+ip_version = "IPv4"
 
 app_gw_name            = "prancer-app-gw"
 app_gw_sku             = "WAF_Medium"
@@ -24,7 +24,7 @@ app_gw_fe_port         = "80"
 app_gw_be_http_cookie  = "Disabled"
 app_gw_be_http_path    = "/login/"
 app_gw_be_http_port    = "80"
-app_gw_be_http_proto   = "Http"
+app_gw_be_http_proto   = "Https"
 app_gw_be_http_timeout = "60"
 app_gw_listener_proto  = "Http"
 app_gw_req_route_type  = "Basic"
@@ -34,7 +34,7 @@ waf_firewall_mode      = "Detection"
 waf_rule_set_type      = "OWASP"
 waf_rule_set_version   = "2.2.9"
 
-tags                   = {
+tags = {
   environment = "Production"
   project     = "Prancer"
 }

--- a/azure/applicationgateways/vars.tf
+++ b/azure/applicationgateways/vars.tf
@@ -20,7 +20,8 @@ variable "app_gw_fe_port" {}
 variable "app_gw_be_http_cookie" {}
 variable "app_gw_be_http_path" {}
 variable "app_gw_be_http_port" {}
-variable "app_gw_be_http_proto" {}
+variable "app_gw_be_http_proto" { default = "Https"
+}
 variable "app_gw_be_http_timeout" {}
 variable "app_gw_listener_proto" {}
 variable "app_gw_req_route_type" {}

--- a/azure/modules/applicationGateway/vars.tf
+++ b/azure/modules/applicationGateway/vars.tf
@@ -10,7 +10,8 @@ variable "app_gw_fe_subnet" {}
 variable "app_gw_be_http_cookie" {}
 variable "app_gw_be_http_path" {}
 variable "app_gw_be_http_port" {}
-variable "app_gw_be_http_proto" {}
+variable "app_gw_be_http_proto" { default = "Https"
+}
 variable "app_gw_be_http_timeout" {}
 variable "app_gw_ip" {}
 variable "app_gw_listener_proto" {}


### PR DESCRIPTION
**Violation Id:** PR-AZR-TRF-AGW-005 

 **Violation Description:** 

 Application Gateway allows to set backend network protocols Http and Https. It is highly recommended to use Https protocol for secure connections. 

 **How to Fix:** 

 For resource type 'azurerm_application_gateway' make sure 'protocol' has value 'https' under 'backend_http_settings' to fix the issue. Please visit <a href='https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_gateway#backend_http_settings' target='_blank'>here</a> for details.