### PR TITLE
Fixed PR-GCP-TRF-FW-018: Ensure GCP Firewall rule logging is enabled

### DIFF
--- a/gcp/modules/compute_firewall/main.tf
+++ b/gcp/modules/compute_firewall/main.tf
@@ -19,4 +19,7 @@ resource "google_compute_firewall" "firewall" {
 
   source_ranges = var.fw_source_ranges
   source_tags   = var.fw_source_tags
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
+  }
 }


### PR DESCRIPTION
**Violation Id:** PR-GCP-TRF-FW-018 

 **Violation Description:** 

 This policy identifies GCP firewall rules that are not configured with firewall rule logging.  Firewall Rules Logging lets you audit, verify, and analyze the effects of your firewall rules. When you enable logging for a firewall rule, Google Cloud creates an entry called a connection record each time the rule allows or denies traffic. 

Reference: https://cloud.google.com/vpc/docs/firewall-rules-logging 

 **How to Fix:** 

 make sure you are following the deployment template format presented <a href='https://cloud.google.com/compute/docs/reference/rest/v1/firewalls' target='_blank'>here</a>