### PR TITLE
Fixed PR-GCP-TRF-INST-015: Ensure GCP VM instances have IP Forwarding enabled.

### DIFF
--- a/gcp/compute_instance/terraform.tfvars
+++ b/gcp/compute_instance/terraform.tfvars
@@ -14,7 +14,7 @@ network                        = "default"
 subnetwork                     = null
 scopes                         = "https://www.googleapis.com/auth/cloud-platform"
 email                          = "testing-compute@developer.gserviceaccount.com"
-can_ip_forward                 = true
-vm_metadata                    = {"block-project-ssh-keys" = false}
+can_ip_forward                 = false
+vm_metadata                    = { "block-project-ssh-keys" = false }
 metadata_startup_script        = ""
 labels                         = {}


### PR DESCRIPTION
**Violation Id:** PR-GCP-TRF-INST-015 

 **Violation Description:** 

 This policy checks VM instances that have IP Forwarding enabled. IP Forwarding could open unintended and undesirable communication paths and allows VM instances to send and receive packets with the non-matching destination or source IPs. To enable the source and destination IP match check, disable IP Forwarding. 

 **How to Fix:** 

 Make sure you are following the deployment template format presented <a href='https://cloud.google.com/compute/docs/reference/rest/v1/instances' target='_blank'>here</a>