### PR TITLE
Fixed PR-GCP-TRF-INST-010: Ensure GCP HTTPS Load balancer is configured with SSL policy not having TLS version 1.1 or lower

### DIFF
--- a/gcp/modules/compute_sslpolicy/main.tf
+++ b/gcp/modules/compute_sslpolicy/main.tf
@@ -1,6 +1,6 @@
 resource "google_compute_ssl_policy" "custom-ssl-policy" {
   name            = "custom-ssl-policy"
-  min_tls_version = "TLS_1_1"
+  min_tls_version = "TLS_1_2"
   profile         = var.profile
   custom_features = ["TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"]
 }


### PR DESCRIPTION
**Violation Id:** PR-GCP-TRF-INST-010 

 **Violation Description:** 

 This policy identifies HTTPS Load balancers is configured with SSL policy having TLS version 1.1 or lower. As a best security practice, use TLS 1.2 as the minimum TLS version in your load balancers SSL security policies. 

 **How to Fix:** 

 make sure you are following the deployment template format presented <a href='https://cloud.google.com/compute/docs/reference/rest/v1/instances' target='_blank'>here</a>