### PR TITLE
Fixed PR-GCP-TRF-SUBN-001: GCP VPC Flow logs for the subnet is set to Off

### DIFF
--- a/gcp/modules/compute_subnetwork/main.tf
+++ b/gcp/modules/compute_subnetwork/main.tf
@@ -14,5 +14,9 @@ resource "google_compute_subnetwork" "subnet" {
     }
   }
 
-  private_ip_google_access = var.private_ip_google_access 
+  private_ip_google_access = var.private_ip_google_access
+  log_config {
+    aggregation_interval = "INTERVAL_5_SEC"
+    metadata             = "INCLUDE_ALL_METADATA"
+  }
 }


### PR DESCRIPTION
**Violation Id:** PR-GCP-TRF-SUBN-001 

 **Violation Description:** 

 This policy identifies the subnets in VPC Network which have Flow logs disabled. It enables to capture information about the IP traffic going to and from network interfaces in VPC Subnets. 

 **How to Fix:** 

 Make sure you are following the deployment template format presented <a href='https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork' target='_blank'>here</a>