### PR TITLE
Fixed PR-GCP-TRF-SUBN-001: GCP VPC Flow logs for the subnet is set to Off

### DIFF
--- a/gcp/compute_subnetwork/terraform.tfvars
+++ b/gcp/compute_subnetwork/terraform.tfvars
@@ -1,5 +1,5 @@
-project    = "learning-269422"
-location   = "us-central1"
+project  = "learning-269422"
+location = "us-central1"
 
 net_name                        = "prancer-network"
 net_description                 = ""
@@ -13,4 +13,4 @@ log_enabled              = false
 log_aggregation_interval = "INTERVAL_10_MIN"
 log_flow_sampling        = 0.5
 log_metadata             = "INCLUDE_ALL_METADATA"
-private_ip_google_access = false
+private_ip_google_access = true


### PR DESCRIPTION
**Violation Id:** PR-GCP-TRF-SUBN-002 

 **Violation Description:** 

 This policy identifies GCP VPC Network subnets have disabled Private Google access. Private Google access enables virtual machine instances on a subnet to reach Google APIs and services using an internal IP address rather than an external IP address. Internal (private) IP addresses are internal to Google Cloud Platform and are not routable or reachable over the Internet. You can use Private Google access to allow VMs without Internet access to reach Google APIs, services, and properties that are accessible over HTTP/HTTPS. 

 **How to Fix:** 

 Make sure you are following the deployment template format presented <a href='https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork' target='_blank'>here</a>