### PR TITLE
Fixed PR-GCP-TRF-THP-002: GCP Load balancer HTTPS target proxy is not configured with QUIC protocol

### DIFF
--- a/gcp/target_proxy/main.tf
+++ b/gcp/target_proxy/main.tf
@@ -2,6 +2,7 @@ resource "google_compute_target_https_proxy" "default" {
   name             = "test-proxy"
   url_map          = google_compute_url_map.default.id
   ssl_certificates = [google_compute_ssl_certificate.default.id]
+  quic_override    = "ENABLE"
 }
 
 resource "google_compute_ssl_certificate" "default" {


### PR DESCRIPTION
**Violation Id:** PR-GCP-TRF-THP-002 

 **Violation Description:** 

 This policy identifies Load Balancer HTTPS target proxies which are not configured with QUIC protocol. Enabling QUIC protocol in load balancer target https proxies adds advantage by establishing connections faster, stream-based multiplexing, improved loss recovery, and eliminates head-of-line blocking. 

 **How to Fix:** 

 make sure you are following the deployment template format presented <a href='https://cloud.google.com/compute/docs/reference/rest/v1/targetHttpsProxies' target='_blank'>here</a>