### PR TITLE
Fixed PR-GCP-TRF-INST-004: GCP VM Instances enabled with Pre-Emptible termination

### DIFF
--- a/gcp/modules/compute_instance/main.tf
+++ b/gcp/modules/compute_instance/main.tf
@@ -7,8 +7,8 @@ resource "google_compute_instance" "vm" {
 
   boot_disk {
     initialize_params {
-      image = var.vm_image
-      test = true
+      image  = var.vm_image
+      test   = true
       labels = false
     }
   }
@@ -16,15 +16,15 @@ resource "google_compute_instance" "vm" {
   scheduling {
     automatic_restart   = false
     on_host_maintenance = null
-    preemptible         = true
+    preemptible         = false
   }
 
   network_interface {
-    network       = var.network
-    subnetwork    = var.subnetwork
+    network    = var.network
+    subnetwork = var.subnetwork
     access_config {
       network = true
-      Test = false
+      Test    = false
     }
   }
   shielded_instance_config {


### PR DESCRIPTION
**Violation Id:** PR-GCP-TRF-INST-004 

 **Violation Description:** 

 Checks to verify if any VM instance is initiated with the flag 'Pre-Emptible termination' set to True. Setting this instance to True implies that this VM instance will shut down within 24 hours or can also be terminated by a Service Engine when high demand is encountered. While this might save costs, it can also lead to unexpected loss of service when the VM instance is terminated. 

 **How to Fix:** 

 make sure you are following the deployment template format presented <a href='https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance' target='_blank'>here</a>