### PR TITLE
Fixed PR-GCP-TRF-INST-001: GCP VM instances have IP forwarding enabled

### DIFF
--- a/gcp/compute_instance/terraform.tfvars
+++ b/gcp/compute_instance/terraform.tfvars
@@ -14,7 +14,7 @@ network                        = "default"
 subnetwork                     = null
 scopes                         = "https://www.googleapis.com/auth/cloud-platform"
 email                          = "testing-compute@developer.gserviceaccount.com"
-can_ip_forward                 = true
-vm_metadata                    = {"block-project-ssh-keys" = false}
+can_ip_forward                 = false
+vm_metadata                    = { "block-project-ssh-keys" = false }
 metadata_startup_script        = ""
 labels                         = {}


### PR DESCRIPTION
**Violation Id:** PR-GCP-TRF-INST-001 

 **Violation Description:** 

 This policy identifies VM instances have IP forwarding enabled. IP Forwarding could open unintended and undesirable communication paths and allows VM instances to send and receive packets with the non-matching destination or source IPs. To enable source and destination IP match check, disable the IP Forwarding. 

 **How to Fix:** 

 make sure you are following the deployment template format presented <a href='https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance' target='_blank'>here</a>