### PR TITLE
Fixed PR-GCP-TRF-INST-009: Ensure GCP HTTPS Load balancer SSL Policy is using restrictive profile

### DIFF
--- a/gcp/compute_sslpolicy/terraform.tfvars
+++ b/gcp/compute_sslpolicy/terraform.tfvars
@@ -1,1 +1,1 @@
-profile = "MORDEN"
+profile = "RESTRICTED"


### PR DESCRIPTION
**Violation Id:** PR-GCP-TRF-INST-009 

 **Violation Description:** 

 This policy identifies HTTPS Load balancers which are not using restrictive profile in it's SSL Policy, which controls sets of features used in negotiating SSL with clients. As a best security practice, use RESTRICTED as SSL policy profile as it meets stricter compliance requirements and does not include any out-of-date SSL features. 

 **How to Fix:** 

 make sure you are following the deployment template format presented <a href='https://cloud.google.com/compute/docs/reference/rest/v1/instances' target='_blank'>here</a>