### PR TITLE
Fixed PR-GCP-TRF-CLT-001: Ensure Kubernetes Engine Cluster Nodes have default Service account for Project access in Google Cloud Provider.

### DIFF
--- a/gcp/modules/container_cluster/vars.tf
+++ b/gcp/modules/container_cluster/vars.tf
@@ -1,37 +1,37 @@
 variable "location" {
-  type = string
+  type    = string
   default = "us-central1"
 }
 variable "k8s_name" {
-  type = string
+  type    = string
   default = ""
 }
 variable "k8s_enable_kubernetes_alpha" {
-  type = bool
+  type    = bool
   default = false
 }
 variable "k8s_enable_legacy_abac" {
-  type = bool
+  type    = bool
   default = false
 }
 variable "k8s_network" {
-  type = string
+  type    = string
   default = null
 }
 variable "k8s_network_policy_enabled" {
-  type = bool
+  type    = bool
   default = false
 }
 variable "master_authorized_networks_config" {
-  type = bool
+  type    = bool
   default = false
 }
 variable "k8s_private_cluster_config" {
-  type = list
+  type    = list
   default = []
 }
 variable "k8s_ip_policy_enabled" {
-  type = bool
+  type    = bool
   default = false
 }
 variable "k8s_ip_policy" {
@@ -41,35 +41,35 @@ variable "k8s_ip_policy" {
   }
 }
 variable "k8s_network_policy_config_disabled" {
-  type = bool
+  type    = bool
   default = true
 }
 variable "k8s_http_load_balancing_disabled" {
-  type = bool
+  type    = bool
   default = true
 }
 variable "k8s_username" {
-  type = string
+  type    = string
   default = ""
 }
 variable "k8s_password" {
-  type = string
+  type    = string
   default = "Root1234"
 }
 variable "k8s_certificate" {
-  type = string
+  type    = string
   default = "false"
 }
 variable "k8s_pod_security_enabled" {
-  type = bool
+  type    = bool
   default = true
 }
 variable "k8s_db_encryption" {
-  type = list
+  type    = list
   default = []
 }
 variable "k8s_enable_binary_auth" {
-  type = bool
+  type    = bool
   default = false
 }
 # variable "k8s_istio_disabled" {
@@ -81,57 +81,57 @@ variable "k8s_enable_binary_auth" {
 #   default = null
 # }
 variable "k8s_monitoring_service" {
-  type = string
+  type    = string
   default = "monitoring.googleapis.com/kubernetes"
 }
 variable "k8s_logging_service" {
-  type = string
+  type    = string
   default = "logging.googleapis.com/kubernetes"
 }
 variable "k8s_resource_labels" {
-  type = map
+  type    = map
   default = {}
 }
 variable "k8s_node_count" {
-  type = number
+  type    = number
   default = 1
 }
 variable "node_locations" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 variable "k8s_image_type" {
-  type = string
+  type    = string
   default = "UBUNTU"
 }
 variable "k8s_preemptible" {
-  type = bool
+  type    = bool
   default = true
 }
 variable "k8s_machine_type" {
-  type = string
+  type    = string
   default = "e2-medium"
 }
 variable "k8s_service_account" {
-  type = string
-  default = null
+  type    = string
+  default = "String<Please provide service account email other than 'default'.>"
 }
 variable "k8s_addons" {
-  type = list
+  type    = list
   default = []
 }
 variable "enable_intranode_visibility" {
-  type = bool
+  type    = bool
   default = false
 }
 variable "k8s_metadata" {
-  type = map
+  type    = map
   default = {}
 }
 variable "k8s_bigquery_dataset" {
   default = null
 }
 variable "enable_network_egress_metering" {
-  type = bool
+  type    = bool
   default = false
 }


### PR DESCRIPTION
**Violation Id:** PR-GCP-TRF-CLT-001 

 **Violation Description:** 

 This policy identifies Kubernetes Engine Cluster Nodes which have default Service account for Project access. By default, Kubernetes Engine nodes are given the Compute Engine default service account. This account has broad access and more permissions than are required to run your Kubernetes Engine cluster. You should create and use a least privileged service account to run your Kubernetes Engine cluster instead of using the Compute Engine default service account. If you are not creating a separate service account for your nodes, you should limit the scopes of the node service account to reduce the possibility of a privilege escalation in an attack. 

 **How to Fix:** 

 make sure you are following the deployment template format presented here for <a href='https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool' target='_blank'>Container Node Pool</a> and <a href='https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster' target='_blank'>Container Cluster</a>