### PR TITLE
Fixed PR-GCP-TRF-CLT-001: Ensure Kubernetes Engine Cluster Nodes have default Service account for Project access in Google Cloud Provider.

### DIFF
--- a/gcp/modules/container_cluster/main.tf
+++ b/gcp/modules/container_cluster/main.tf
@@ -1,13 +1,13 @@
 resource "google_container_cluster" "primary" {
-  name                     = var.k8s_name
-  location                 = var.location
-  enable_shielded_nodes    = false
+  name                  = var.k8s_name
+  location              = var.location
+  enable_shielded_nodes = false
 
   remove_default_node_pool = true
   initial_node_count       = 1
 
-  enable_kubernetes_alpha  = var.k8s_enable_kubernetes_alpha
-  enable_legacy_abac       = var.k8s_enable_legacy_abac
+  enable_kubernetes_alpha = var.k8s_enable_kubernetes_alpha
+  enable_legacy_abac      = var.k8s_enable_legacy_abac
 
   network = var.k8s_network
 
@@ -112,16 +112,16 @@ resource "google_container_node_pool" "nodes" {
   node_locations = var.node_locations
 
   node_config {
-    image_type            = var.k8s_image_type
-    preemptible           = var.k8s_preemptible
-    machine_type          = var.k8s_machine_type
-    service_account       = null
-    metadata              = var.k8s_metadata
-    
-  management {
-    auto_repair  = false
-    auto_upgrade = false
-  }
+    image_type      = var.k8s_image_type
+    preemptible     = var.k8s_preemptible
+    machine_type    = var.k8s_machine_type
+    service_account = "String<Please provide service account email other than 'default'.>"
+    metadata        = var.k8s_metadata
+
+    management {
+      auto_repair  = false
+      auto_upgrade = false
+    }
     shielded_instance_config {
       enable_secure_boot          = false
       enable_integrity_monitoring = false


### PR DESCRIPTION
**Violation Id:** PR-GCP-TRF-CLT-001 

 **Violation Description:** 

 This policy identifies Kubernetes Engine Cluster Nodes which have default Service account for Project access. By default, Kubernetes Engine nodes are given the Compute Engine default service account. This account has broad access and more permissions than are required to run your Kubernetes Engine cluster. You should create and use a least privileged service account to run your Kubernetes Engine cluster instead of using the Compute Engine default service account. If you are not creating a separate service account for your nodes, you should limit the scopes of the node service account to reduce the possibility of a privilege escalation in an attack. 

 **How to Fix:** 

 make sure you are following the deployment template format presented here for <a href='https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool' target='_blank'>Container Node Pool</a> and <a href='https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster' target='_blank'>Container Cluster</a>